### PR TITLE
ci: update build container image to use node 14

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,4 +71,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     container:
-      image: jsii/superchain
+      image: jsii/superchain:1-buster-slim-node14

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -71,4 +71,4 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     container:
-      image: jsii/superchain:1-buster-slim-node14
+      image: jsii/superchain:node14

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,7 +71,7 @@ jobs:
           name: dist
           path: dist
     container:
-      image: jsii/superchain
+      image: jsii/superchain:1-buster-slim-node14
   release_github:
     name: Publish to GitHub Releases
     needs: release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -71,7 +71,7 @@ jobs:
           name: dist
           path: dist
     container:
-      image: jsii/superchain:1-buster-slim-node14
+      image: jsii/superchain:node14
   release_github:
     name: Publish to GitHub Releases
     needs: release

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -34,7 +34,7 @@ jobs:
           name: .upgrade.tmp.patch
           path: .upgrade.tmp.patch
     container:
-      image: jsii/superchain
+      image: jsii/superchain:1-buster-slim-node14
   pr:
     name: Create Pull Request
     needs: upgrade

--- a/.github/workflows/upgrade.yml
+++ b/.github/workflows/upgrade.yml
@@ -34,7 +34,7 @@ jobs:
           name: .upgrade.tmp.patch
           path: .upgrade.tmp.patch
     container:
-      image: jsii/superchain:1-buster-slim-node14
+      image: jsii/superchain:node14
   pr:
     name: Create Pull Request
     needs: upgrade

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -90,7 +90,7 @@ const project = new AwsCdkConstructLibrary({
       labels: ['auto-approve'],
       secret: 'CDK_AUTOMATION_GITHUB_TOKEN',
       container: {
-        image: 'jsii/superchain',
+        image: 'jsii/superchain:1-buster-slim-node14',
       },
     },
   }),
@@ -251,7 +251,7 @@ project.release.addJobs({
       },
     ],
     container: {
-      image: 'jsii/superchain',
+      image: 'jsii/superchain:1-buster-slim-node14',
     },
   },
 });

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -90,7 +90,7 @@ const project = new AwsCdkConstructLibrary({
       labels: ['auto-approve'],
       secret: 'CDK_AUTOMATION_GITHUB_TOKEN',
       container: {
-        image: 'jsii/superchain:1-buster-slim-node14',
+        image: 'jsii/superchain:node14',
       },
     },
   }),
@@ -171,7 +171,7 @@ project.buildWorkflow.file.addOverride('jobs.build.steps', [
   },
 ]);
 project.buildWorkflow.file.addOverride('jobs.build.container', {
-  image: 'jsii/superchain:1-buster-slim-node14',
+  image: 'jsii/superchain:node14',
 });
 project.release.addJobs({
   release: {
@@ -254,7 +254,7 @@ project.release.addJobs({
       },
     ],
     container: {
-      image: 'jsii/superchain:1-buster-slim-node14',
+      image: 'jsii/superchain:node14',
     },
   },
 });

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -170,6 +170,9 @@ project.buildWorkflow.file.addOverride('jobs.build.steps', [
     },
   },
 ]);
+project.buildWorkflow.file.addOverride('jobs.build.container', {
+  image: 'jsii/superchain:1-buster-slim-node14',
+});
 project.release.addJobs({
   release: {
     runsOn: 'ubuntu-latest',

--- a/.projenrc.monocdk.js
+++ b/.projenrc.monocdk.js
@@ -10,7 +10,7 @@ const project = new AwsCdkConstructLibrary({
   defaultReleaseBranch: 'main',
   name: 'monocdk-nag',
   description:
-    'Check CDK applications for best practices using a combination on available rule packs..',
+    'Check CDK applications for best practices using a combination on available rule packs.',
   repositoryUrl: 'https://github.com/cdklabs/cdk-nag.git',
 
   cdkDependencies: ['monocdk'],

--- a/.projenrc.monocdk.js
+++ b/.projenrc.monocdk.js
@@ -20,4 +20,7 @@ const project = new AwsCdkConstructLibrary({
     module: 'monocdk_nag',
   },
 });
+project.package.addField('resolutions', {
+  'trim-newlines': '3.0.1',
+});
 project.synth();


### PR DESCRIPTION
monocdk builds started to fail due to the CI image using node v10 and a dependency requiring node > v12, as [seen here](https://github.com/cdklabs/cdk-nag/runs/3510017434?check_suite_focus=true). Updating the build and release container images to a node 14 based image to remediate that issue 


----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*