### PR TITLE
feat(core): Intrinsic Function handling

### DIFF
--- a/src/AwsSolutions/rules/analytics/ATH1.ts
+++ b/src/AwsSolutions/rules/analytics/ATH1.ts
@@ -4,6 +4,7 @@ SPDX-License-Identifier: Apache-2.0
 */
 import { CfnWorkGroup } from '@aws-cdk/aws-athena';
 import { CfnResource, Stack } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../..';
 
 /**
  * Athena workgroups encrypt query results
@@ -25,13 +26,15 @@ export default function (node: CfnResource): boolean {
         workGroupConfigurationUpdates.resultConfigurationUpdates
       );
       if (resultConfigurationUpdates != undefined) {
-        const removeEncryptionConfiguration = Stack.of(node).resolve(
+        const removeEncryptionConfiguration = resolveIfPrimitive(
+          node,
           resultConfigurationUpdates.removeEncryptionConfiguration
         );
         const encryptionConfiguration = Stack.of(node).resolve(
           resultConfigurationUpdates.encryptionConfiguration
         );
-        const enforceWorkGroupConfiguration = Stack.of(node).resolve(
+        const enforceWorkGroupConfiguration = resolveIfPrimitive(
+          node,
           workGroupConfigurationUpdates.enforceWorkGroupConfiguration
         );
         if (
@@ -47,7 +50,8 @@ export default function (node: CfnResource): boolean {
         }
       }
     } else {
-      const enforceWorkGroupConfiguration = Stack.of(node).resolve(
+      const enforceWorkGroupConfiguration = resolveIfPrimitive(
+        node,
         workGroupConfiguration.enforceWorkGroupConfiguration
       );
       if (!enforceWorkGroupConfiguration) {
@@ -56,12 +60,14 @@ export default function (node: CfnResource): boolean {
       const resultConfiguration = Stack.of(node).resolve(
         workGroupConfiguration.resultConfiguration
       );
+
       if (resultConfiguration == undefined) {
         return false;
       }
       const encryptionConfiguration = Stack.of(node).resolve(
         resultConfiguration.encryptionConfiguration
       );
+
       if (encryptionConfiguration == undefined) {
         return false;
       }

--- a/src/AwsSolutions/rules/analytics/KDA3.ts
+++ b/src/AwsSolutions/rules/analytics/KDA3.ts
@@ -4,6 +4,7 @@ SPDX-License-Identifier: Apache-2.0
 */
 import { CfnApplicationV2 } from '@aws-cdk/aws-kinesisanalytics';
 import { CfnResource, Stack } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * Kinesis Data Analytics Flink Applications have checkpointing enabled
@@ -30,8 +31,12 @@ export default function (node: CfnResource): boolean {
       if (checkpointConfiguration == undefined) {
         return false;
       }
-      if (checkpointConfiguration.configurationType == 'CUSTOM') {
-        const enabled = Stack.of(node).resolve(
+      if (
+        resolveIfPrimitive(node, checkpointConfiguration.configurationType) ==
+        'CUSTOM'
+      ) {
+        const enabled = resolveIfPrimitive(
+          node,
           checkpointConfiguration.checkpointingEnabled
         );
         if (!enabled) {

--- a/src/AwsSolutions/rules/analytics/MSK2.ts
+++ b/src/AwsSolutions/rules/analytics/MSK2.ts
@@ -4,6 +4,7 @@ SPDX-License-Identifier: Apache-2.0
 */
 import { CfnCluster, ClientBrokerEncryption } from '@aws-cdk/aws-msk';
 import { CfnResource, Stack } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * MSK clusters only uses TLS communication between clients and brokers
@@ -17,7 +18,8 @@ export default function (node: CfnResource): boolean {
         encryptionInfo.encryptionInTransit
       );
       if (encryptionInTransit != undefined) {
-        const clientBroker = Stack.of(node).resolve(
+        const clientBroker = resolveIfPrimitive(
+          node,
           encryptionInTransit.clientBroker
         );
         if (

--- a/src/AwsSolutions/rules/analytics/MSK3.ts
+++ b/src/AwsSolutions/rules/analytics/MSK3.ts
@@ -4,6 +4,7 @@ SPDX-License-Identifier: Apache-2.0
 */
 import { CfnCluster } from '@aws-cdk/aws-msk';
 import { CfnResource, Stack } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * MSK clusters use TLS communication between brokers
@@ -17,8 +18,11 @@ export default function (node: CfnResource): boolean {
         encryptionInfo.encryptionInTransit
       );
       if (encryptionInTransit != undefined) {
-        const inCluster = Stack.of(node).resolve(encryptionInTransit.inCluster);
-        if (inCluster != undefined && inCluster == false) {
+        const inCluster = resolveIfPrimitive(
+          node,
+          encryptionInTransit.inCluster
+        );
+        if (inCluster === false) {
           return false;
         }
       }

--- a/src/AwsSolutions/rules/analytics/MSK6.ts
+++ b/src/AwsSolutions/rules/analytics/MSK6.ts
@@ -4,6 +4,7 @@ SPDX-License-Identifier: Apache-2.0
 */
 import { CfnCluster } from '@aws-cdk/aws-msk';
 import { CfnResource, Stack } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * MSK clusters send broker logs to a supported destination
@@ -19,7 +20,7 @@ export default function (node: CfnResource): boolean {
     let enabled = false;
     const s3 = Stack.of(node).resolve(resolvedBrokerLogs.s3);
     if (s3 != undefined) {
-      const s3Enabled = Stack.of(node).resolve(s3.enabled);
+      const s3Enabled = resolveIfPrimitive(node, s3.enabled);
       if (s3Enabled) {
         enabled = true;
       }
@@ -28,7 +29,8 @@ export default function (node: CfnResource): boolean {
       resolvedBrokerLogs.cloudWatchLogs
     );
     if (cloudWatchLogs != undefined) {
-      const cloudWatchLogsEnabled = Stack.of(node).resolve(
+      const cloudWatchLogsEnabled = resolveIfPrimitive(
+        node,
         cloudWatchLogs.enabled
       );
       if (cloudWatchLogsEnabled) {
@@ -37,7 +39,7 @@ export default function (node: CfnResource): boolean {
     }
     const firehose = Stack.of(node).resolve(resolvedBrokerLogs.firehose);
     if (firehose != undefined) {
-      const firehoseEnabled = Stack.of(node).resolve(firehose.enabled);
+      const firehoseEnabled = resolveIfPrimitive(node, firehose.enabled);
       if (firehoseEnabled) {
         enabled = true;
       }

--- a/src/AwsSolutions/rules/analytics/OS2.ts
+++ b/src/AwsSolutions/rules/analytics/OS2.ts
@@ -4,6 +4,7 @@ SPDX-License-Identifier: Apache-2.0
 */
 import { CfnDomain } from '@aws-cdk/aws-elasticsearch';
 import { CfnResource, Stack } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * OpenSearch Service domains have node-to-node encryption enabled
@@ -17,7 +18,10 @@ export default function (node: CfnResource): boolean {
     if (nodeToNodeEncryptionOptions == undefined) {
       return false;
     }
-    const enabled = Stack.of(node).resolve(nodeToNodeEncryptionOptions.enabled);
+    const enabled = resolveIfPrimitive(
+      node,
+      nodeToNodeEncryptionOptions.enabled
+    );
     if (!enabled) {
       return false;
     }

--- a/src/AwsSolutions/rules/analytics/OS4.ts
+++ b/src/AwsSolutions/rules/analytics/OS4.ts
@@ -4,6 +4,7 @@ SPDX-License-Identifier: Apache-2.0
 */
 import { CfnDomain } from '@aws-cdk/aws-elasticsearch';
 import { CfnResource, Stack } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * OpenSearch Service domains use dedicated master nodes
@@ -17,7 +18,8 @@ export default function (node: CfnResource): boolean {
     if (elasticsearchClusterConfig == undefined) {
       return false;
     }
-    const dedicatedMasterEnabled = Stack.of(node).resolve(
+    const dedicatedMasterEnabled = resolveIfPrimitive(
+      node,
       elasticsearchClusterConfig.dedicatedMasterEnabled
     );
     if (!dedicatedMasterEnabled) {

--- a/src/AwsSolutions/rules/analytics/OS7.ts
+++ b/src/AwsSolutions/rules/analytics/OS7.ts
@@ -4,6 +4,7 @@ SPDX-License-Identifier: Apache-2.0
 */
 import { CfnDomain } from '@aws-cdk/aws-elasticsearch';
 import { CfnResource, Stack } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * OpenSearch Service domains have Zone Awareness enabled
@@ -17,7 +18,8 @@ export default function (node: CfnResource): boolean {
     if (elasticsearchClusterConfig == undefined) {
       return false;
     }
-    const zoneAwarenessEnabled = Stack.of(node).resolve(
+    const zoneAwarenessEnabled = resolveIfPrimitive(
+      node,
       elasticsearchClusterConfig.zoneAwarenessEnabled
     );
     if (!zoneAwarenessEnabled) {

--- a/src/AwsSolutions/rules/analytics/OS8.ts
+++ b/src/AwsSolutions/rules/analytics/OS8.ts
@@ -4,6 +4,7 @@ SPDX-License-Identifier: Apache-2.0
 */
 import { CfnDomain } from '@aws-cdk/aws-elasticsearch';
 import { CfnResource, Stack } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * OpenSearch Service domains have encryption at rest enabled
@@ -17,7 +18,7 @@ export default function (node: CfnResource): boolean {
     if (encryptionAtRestOptions == undefined) {
       return false;
     }
-    const enabled = Stack.of(node).resolve(encryptionAtRestOptions.enabled);
+    const enabled = resolveIfPrimitive(node, encryptionAtRestOptions.enabled);
     if (!enabled) {
       return false;
     }

--- a/src/AwsSolutions/rules/analytics/OS9.ts
+++ b/src/AwsSolutions/rules/analytics/OS9.ts
@@ -4,6 +4,7 @@ SPDX-License-Identifier: Apache-2.0
 */
 import { CfnDomain } from '@aws-cdk/aws-elasticsearch';
 import { CfnResource, Stack } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * OpenSearch Service domains minimally publish SEARCH_SLOW_LOGS and INDEX_SLOW_LOGS to CloudWatch Logs
@@ -26,7 +27,7 @@ export default function (node: CfnResource): boolean {
       if (resolvedLog == undefined) {
         return false;
       }
-      const enabled = Stack.of(node).resolve(resolvedLog.enabled);
+      const enabled = resolveIfPrimitive(node, resolvedLog.enabled);
       if (!enabled) {
         return false;
       }

--- a/src/AwsSolutions/rules/analytics/QS1.ts
+++ b/src/AwsSolutions/rules/analytics/QS1.ts
@@ -4,6 +4,7 @@ SPDX-License-Identifier: Apache-2.0
 */
 import { CfnDataSource } from '@aws-cdk/aws-quicksight';
 import { CfnResource, Stack } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * Quicksight uses SSL when connecting to a data source
@@ -13,8 +14,8 @@ export default function (node: CfnResource): boolean {
   if (node instanceof CfnDataSource) {
     const sslProperties = Stack.of(node).resolve(node.sslProperties);
     if (sslProperties != undefined) {
-      const disableSsl = Stack.of(node).resolve(sslProperties.disableSsl);
-      if (disableSsl != undefined && disableSsl) {
+      const disableSsl = resolveIfPrimitive(node, sslProperties.disableSsl);
+      if (disableSsl === true) {
         return false;
       }
     }

--- a/src/AwsSolutions/rules/compute/EC23.ts
+++ b/src/AwsSolutions/rules/compute/EC23.ts
@@ -4,6 +4,7 @@ SPDX-License-Identifier: Apache-2.0
 */
 import { CfnSecurityGroup, CfnSecurityGroupIngress } from '@aws-cdk/aws-ec2';
 import { CfnResource, Stack } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * EC2 security groups do not allow for 0.0.0.0/0 or ::/0 inbound access
@@ -15,25 +16,26 @@ export default function (node: CfnResource): boolean {
     if (ingressRules != undefined) {
       for (const rule of ingressRules) {
         const resolvedRule = Stack.of(node).resolve(rule);
-        if (
-          resolvedRule.cidrIp != undefined &&
-          resolvedRule.cidrIp.includes('/0')
-        ) {
+        const resolvedcidrIp = resolveIfPrimitive(node, resolvedRule.cidrIp);
+        const resolvedcidrIpv6 = resolveIfPrimitive(
+          node,
+          resolvedRule.cidrIpv6
+        );
+        if (resolvedcidrIp != undefined && resolvedcidrIp.includes('/0')) {
           return false;
         }
-        if (
-          resolvedRule.cidrIpv6 != undefined &&
-          resolvedRule.cidrIpv6.includes('/0')
-        ) {
+        if (resolvedcidrIpv6 != undefined && resolvedcidrIpv6.includes('/0')) {
           return false;
         }
       }
     }
   } else if (node instanceof CfnSecurityGroupIngress) {
-    if (node.cidrIp != undefined && node.cidrIp.includes('/0')) {
+    const resolvedcidrIp = resolveIfPrimitive(node, node.cidrIp);
+    const resolvedcidrIpv6 = resolveIfPrimitive(node, node.cidrIpv6);
+    if (resolvedcidrIp != undefined && resolvedcidrIp.includes('/0')) {
       return false;
     }
-    if (node.cidrIpv6 != undefined && node.cidrIpv6.includes('/0')) {
+    if (resolvedcidrIpv6 != undefined && resolvedcidrIpv6.includes('/0')) {
       return false;
     }
   }

--- a/src/AwsSolutions/rules/compute/EC26.ts
+++ b/src/AwsSolutions/rules/compute/EC26.ts
@@ -3,7 +3,8 @@ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 import { CfnVolume } from '@aws-cdk/aws-ec2';
-import { CfnResource, Stack } from '@aws-cdk/core';
+import { CfnResource } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * EBS volumes have encryption enabled
@@ -11,8 +12,8 @@ import { CfnResource, Stack } from '@aws-cdk/core';
  */
 export default function (node: CfnResource): boolean {
   if (node instanceof CfnVolume) {
-    const encryption = Stack.of(node).resolve(node.encrypted);
-    if (encryption == undefined || encryption == false) {
+    const encryption = resolveIfPrimitive(node, node.encrypted);
+    if (encryption !== true) {
       return false;
     }
   }

--- a/src/AwsSolutions/rules/compute/EC27.ts
+++ b/src/AwsSolutions/rules/compute/EC27.ts
@@ -4,6 +4,7 @@ SPDX-License-Identifier: Apache-2.0
 */
 import { CfnSecurityGroup } from '@aws-cdk/aws-ec2';
 import { CfnResource } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * Security Groups have descriptions
@@ -11,7 +12,7 @@ import { CfnResource } from '@aws-cdk/core';
  */
 export default function (node: CfnResource): boolean {
   if (node instanceof CfnSecurityGroup) {
-    const description = node.groupDescription;
+    const description = resolveIfPrimitive(node, node.groupDescription);
     if (description.length < 2) {
       return false;
     }

--- a/src/AwsSolutions/rules/compute/EC28.ts
+++ b/src/AwsSolutions/rules/compute/EC28.ts
@@ -4,7 +4,8 @@ SPDX-License-Identifier: Apache-2.0
 */
 import { CfnLaunchConfiguration } from '@aws-cdk/aws-autoscaling';
 import { CfnInstance } from '@aws-cdk/aws-ec2';
-import { CfnResource, Stack } from '@aws-cdk/core';
+import { CfnResource } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * EC2 Instances have detailed monitoring enabled
@@ -12,13 +13,13 @@ import { CfnResource, Stack } from '@aws-cdk/core';
  */
 export default function (node: CfnResource): boolean {
   if (node instanceof CfnInstance) {
-    const monitoring = Stack.of(node).resolve(node.monitoring);
-    if (monitoring == undefined || monitoring == false) {
+    const monitoring = resolveIfPrimitive(node, node.monitoring);
+    if (monitoring !== true) {
       return false;
     }
   } else if (node instanceof CfnLaunchConfiguration) {
-    const monitoring = Stack.of(node).resolve(node.instanceMonitoring);
-    if (monitoring != undefined && monitoring == false) {
+    const monitoring = resolveIfPrimitive(node, node.instanceMonitoring);
+    if (monitoring === false) {
       return false;
     }
   }

--- a/src/AwsSolutions/rules/compute/EC29.ts
+++ b/src/AwsSolutions/rules/compute/EC29.ts
@@ -3,7 +3,8 @@ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 import { CfnInstance } from '@aws-cdk/aws-ec2';
-import { CfnResource, Stack } from '@aws-cdk/core';
+import { CfnResource } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * EC2 Instances outside of an ASG have Termination Protection enabled
@@ -11,10 +12,11 @@ import { CfnResource, Stack } from '@aws-cdk/core';
  */
 export default function (node: CfnResource): boolean {
   if (node instanceof CfnInstance) {
-    const disableApiTermination = Stack.of(node).resolve(
+    const disableApiTermination = resolveIfPrimitive(
+      node,
       node.disableApiTermination
     );
-    if (disableApiTermination == undefined || disableApiTermination == false) {
+    if (disableApiTermination !== true) {
       return false;
     }
   }

--- a/src/AwsSolutions/rules/compute/ECS7.ts
+++ b/src/AwsSolutions/rules/compute/ECS7.ts
@@ -4,6 +4,7 @@ SPDX-License-Identifier: Apache-2.0
 */
 import { CfnCluster } from '@aws-cdk/aws-ecs';
 import { CfnResource, Stack } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * ECS Task Definition has awslogs logging enabled at the minimum
@@ -18,7 +19,8 @@ export default function (node: CfnResource): boolean {
     if (configuration.executeCommandConfiguration == undefined) {
       return false;
     }
-    const executeCommandConfiguration = Stack.of(node).resolve(
+    const executeCommandConfiguration = resolveIfPrimitive(
+      node,
       configuration.executeCommandConfiguration
     );
     if (

--- a/src/AwsSolutions/rules/compute/ELB1.ts
+++ b/src/AwsSolutions/rules/compute/ELB1.ts
@@ -4,6 +4,7 @@ SPDX-License-Identifier: Apache-2.0
 */
 import { CfnLoadBalancer } from '@aws-cdk/aws-elasticloadbalancing';
 import { CfnResource, Stack } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * CLBs are not used for incoming HTTP/HTTPS traffic. Use ALBs instead.
@@ -14,9 +15,10 @@ export default function (node: CfnResource): boolean {
     const listeners = Stack.of(node).resolve(node.listeners);
     for (const listener of listeners) {
       const resolvedListener = Stack.of(node).resolve(listener);
+      const protocol = resolveIfPrimitive(node, resolvedListener.protocol);
       if (
-        resolvedListener.protocol.toLowerCase() == 'http' ||
-        resolvedListener.protocol.toLowerCase() == 'https'
+        protocol.toLowerCase() == 'http' ||
+        protocol.toLowerCase() == 'https'
       ) {
         return false;
       }

--- a/src/AwsSolutions/rules/compute/ELB2a.ts
+++ b/src/AwsSolutions/rules/compute/ELB2a.ts
@@ -4,6 +4,7 @@ SPDX-License-Identifier: Apache-2.0
 */
 import { CfnLoadBalancer } from '@aws-cdk/aws-elasticloadbalancingv2';
 import { CfnResource, Stack } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * ALBs have access logs enabled.
@@ -11,19 +12,22 @@ import { CfnResource, Stack } from '@aws-cdk/core';
  */
 export default function (node: CfnResource): boolean {
   if (node instanceof CfnLoadBalancer) {
-    const type = Stack.of(node).resolve(node.type);
+    const type = resolveIfPrimitive(node, node.type);
     if (type == undefined || type == 'application') {
       const attributes = Stack.of(node).resolve(node.loadBalancerAttributes);
+      let found = false;
       for (const attribute of attributes) {
         const resolvedAttribute = Stack.of(node).resolve(attribute);
-        if (
-          resolvedAttribute.key == 'access_logs.s3.enabled' ||
-          resolvedAttribute.value == 'true'
-        ) {
-          return true;
+        const key = resolveIfPrimitive(node, resolvedAttribute.key);
+        const value = resolveIfPrimitive(node, resolvedAttribute.value);
+        if (key == 'access_logs.s3.enabled' && value == 'true') {
+          found = true;
+          break;
         }
       }
-      return false;
+      if (!found) {
+        return false;
+      }
     }
   }
   return true;

--- a/src/AwsSolutions/rules/compute/ELB2e.ts
+++ b/src/AwsSolutions/rules/compute/ELB2e.ts
@@ -4,6 +4,7 @@ SPDX-License-Identifier: Apache-2.0
 */
 import { CfnLoadBalancer } from '@aws-cdk/aws-elasticloadbalancing';
 import { CfnResource, Stack } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * CLBs have access logs enabled.
@@ -17,7 +18,7 @@ export default function (node: CfnResource): boolean {
     const accessLoggingPolicy = Stack.of(node).resolve(
       node.accessLoggingPolicy
     );
-    const enabled = Stack.of(node).resolve(accessLoggingPolicy.enabled);
+    const enabled = resolveIfPrimitive(node, accessLoggingPolicy.enabled);
 
     if (enabled == false) {
       return false;

--- a/src/AwsSolutions/rules/compute/ELB3.ts
+++ b/src/AwsSolutions/rules/compute/ELB3.ts
@@ -4,6 +4,7 @@ SPDX-License-Identifier: Apache-2.0
 */
 import { CfnLoadBalancer } from '@aws-cdk/aws-elasticloadbalancing';
 import { CfnResource, Stack } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * CLBs have connection draining enabled.
@@ -16,7 +17,8 @@ export default function (node: CfnResource): boolean {
     }
     const draining = Stack.of(node).resolve(node.connectionDrainingPolicy);
     const resolvedDraining = Stack.of(node).resolve(draining);
-    if (!(resolvedDraining.enabled == true)) {
+    const enabled = resolveIfPrimitive(node, resolvedDraining.enabled);
+    if (enabled !== true) {
       return false;
     }
   }

--- a/src/AwsSolutions/rules/compute/ELB4.ts
+++ b/src/AwsSolutions/rules/compute/ELB4.ts
@@ -3,7 +3,8 @@ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 import { CfnLoadBalancer } from '@aws-cdk/aws-elasticloadbalancing';
-import { CfnResource, Stack } from '@aws-cdk/core';
+import { CfnResource } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * CLBs use at least two AZs with the Cross-Zone Load Balancing feature enabled.
@@ -24,8 +25,8 @@ export default function (node: CfnResource): boolean {
     } else if (node.subnets.length < 2) {
       return false;
     }
-    const crossZone = Stack.of(node).resolve(node.crossZone);
-    if (crossZone != true) {
+    const crossZone = resolveIfPrimitive(node, node.crossZone);
+    if (crossZone !== true) {
       return false;
     }
   }

--- a/src/AwsSolutions/rules/compute/ELB5.ts
+++ b/src/AwsSolutions/rules/compute/ELB5.ts
@@ -4,6 +4,7 @@ SPDX-License-Identifier: Apache-2.0
 */
 import { CfnLoadBalancer } from '@aws-cdk/aws-elasticloadbalancing';
 import { CfnResource, Stack } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * ELB listeners should be configured for secure (HTTPs or SSL) protocols for client communication.
@@ -14,20 +15,25 @@ export default function (node: CfnResource): boolean {
     const listeners = Stack.of(node).resolve(node.listeners);
     for (const listener of listeners) {
       const resolvedListener = Stack.of(node).resolve(listener);
-      if (resolvedListener.protocol.toLowerCase() == 'ssl') {
+      const protocol = resolveIfPrimitive(node, resolvedListener.protocol);
+      const instanceProtocol = resolveIfPrimitive(
+        node,
+        resolvedListener.instanceProtocol
+      );
+      if (protocol.toLowerCase() == 'ssl') {
         if (
           !(
-            resolvedListener.instanceProtocol == undefined ||
-            resolvedListener.instanceProtocol.toLowerCase() == 'ssl'
+            instanceProtocol == undefined ||
+            instanceProtocol.toLowerCase() == 'ssl'
           )
         ) {
           return false;
         }
-      } else if (resolvedListener.protocol.toLowerCase() == 'https') {
+      } else if (protocol.toLowerCase() == 'https') {
         if (
           !(
-            resolvedListener.instanceProtocol == undefined ||
-            resolvedListener.instanceProtocol.toLowerCase() == 'https'
+            instanceProtocol == undefined ||
+            instanceProtocol.toLowerCase() == 'https'
           )
         ) {
           return false;

--- a/src/AwsSolutions/rules/databases/AEC1.ts
+++ b/src/AwsSolutions/rules/databases/AEC1.ts
@@ -10,14 +10,7 @@ import { CfnResource } from '@aws-cdk/core';
  * @param node the CfnResource to check
  */
 export default function (node: CfnResource): boolean {
-  if (node instanceof CfnCacheCluster) {
-    if (
-      node.cacheSubnetGroupName == undefined ||
-      node.cacheSubnetGroupName.length == 0
-    ) {
-      return false;
-    }
-  } else if (node instanceof CfnReplicationGroup) {
+  if (node instanceof CfnCacheCluster || node instanceof CfnReplicationGroup) {
     if (
       node.cacheSubnetGroupName == undefined ||
       node.cacheSubnetGroupName.length == 0

--- a/src/AwsSolutions/rules/databases/AEC3.ts
+++ b/src/AwsSolutions/rules/databases/AEC3.ts
@@ -3,7 +3,8 @@ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 import { CfnReplicationGroup } from '@aws-cdk/aws-elasticache';
-import { CfnResource, Stack } from '@aws-cdk/core';
+import { CfnResource } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * ElastiCache Redis clusters have both encryption in transit and at rest enabled
@@ -17,8 +18,8 @@ export default function (node: CfnResource): boolean {
     ) {
       return false;
     }
-    const rest = Stack.of(node).resolve(node.atRestEncryptionEnabled);
-    const transit = Stack.of(node).resolve(node.transitEncryptionEnabled);
+    const rest = resolveIfPrimitive(node, node.atRestEncryptionEnabled);
+    const transit = resolveIfPrimitive(node, node.transitEncryptionEnabled);
     if (rest == false || transit == false) {
       return false;
     }

--- a/src/AwsSolutions/rules/databases/AEC4.ts
+++ b/src/AwsSolutions/rules/databases/AEC4.ts
@@ -3,7 +3,8 @@ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 import { CfnReplicationGroup } from '@aws-cdk/aws-elasticache';
-import { CfnResource, Stack } from '@aws-cdk/core';
+import { CfnResource } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * ElastiCache Redis clusters are deployed in a Multi-AZ configuration
@@ -14,7 +15,7 @@ export default function (node: CfnResource): boolean {
     if (node.multiAzEnabled == undefined) {
       return false;
     }
-    const multiAz = Stack.of(node).resolve(node.multiAzEnabled);
+    const multiAz = resolveIfPrimitive(node, node.multiAzEnabled);
     if (!multiAz) {
       return false;
     }

--- a/src/AwsSolutions/rules/databases/AEC5.ts
+++ b/src/AwsSolutions/rules/databases/AEC5.ts
@@ -4,6 +4,7 @@ SPDX-License-Identifier: Apache-2.0
 */
 import { CfnReplicationGroup, CfnCacheCluster } from '@aws-cdk/aws-elasticache';
 import { CfnResource } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * ElastiCache clusters do not use the default endpoint ports
@@ -11,22 +12,25 @@ import { CfnResource } from '@aws-cdk/core';
  */
 export default function (node: CfnResource): boolean {
   if (node instanceof CfnCacheCluster) {
-    if (node.port == undefined) {
+    const port = resolveIfPrimitive(node, node.port);
+    if (port == undefined) {
       return false;
     }
-    const engine = node.engine.toLowerCase();
-    if (engine == 'redis' && node.port == 6379) {
+    const engine = resolveIfPrimitive(node, node.engine);
+    if (engine.toLowerCase() == 'redis' && port == 6379) {
       return false;
-    } else if (engine == 'memcached' && node.port == 11211) {
+    } else if (engine.toLowerCase() == 'memcached' && port == 11211) {
       return false;
     }
   } else if (node instanceof CfnReplicationGroup) {
-    if (node.port == undefined) {
+    const port = resolveIfPrimitive(node, node.port);
+    if (port == undefined) {
       return false;
     }
+    const engine = resolveIfPrimitive(node, node.engine);
     if (
-      (node.engine == undefined || node.engine.toLowerCase() == 'redis') &&
-      node.port == 6379
+      (engine == undefined || engine.toLowerCase() == 'redis') &&
+      port == 6379
     ) {
       return false;
     }

--- a/src/AwsSolutions/rules/databases/DDB3.ts
+++ b/src/AwsSolutions/rules/databases/DDB3.ts
@@ -4,6 +4,7 @@ SPDX-License-Identifier: Apache-2.0
 */
 import { CfnTable } from '@aws-cdk/aws-dynamodb';
 import { CfnResource, Stack } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * DynamoDB tables have Point-in-time Recovery enabled
@@ -15,24 +16,10 @@ export default function (node: CfnResource): boolean {
       return false;
     }
     const pitr = Stack.of(node).resolve(node.pointInTimeRecoverySpecification);
-    const enabled = Stack.of(node).resolve(pitr.pointInTimeRecoveryEnabled);
+    const enabled = resolveIfPrimitive(node, pitr.pointInTimeRecoveryEnabled);
     if (!enabled) {
       return false;
     }
   }
-  //  else if (node instanceof CfnGlobalTable) {
-  //   if (node.pointInTimeRecoverySpecification == undefined) {
-  //     return false;
-  //   }
-  //   const pitr = Tokenization.isResolvable(
-  //     node.pointInTimeRecoverySpecification,
-  //   )
-  //     ? Stack.of(node).resolve(node.pointInTimeRecoverySpecification)
-  //     : node.pointInTimeRecoverySpecification;
-  //   const enabled = Stack.of(node).resolve(pitr.pointInTimeRecoveryEnabled);
-  //   if (!enabled) {
-  //     return false;
-  //   }
-  // }
   return true;
 }

--- a/src/AwsSolutions/rules/databases/DDB4.ts
+++ b/src/AwsSolutions/rules/databases/DDB4.ts
@@ -4,6 +4,7 @@ SPDX-License-Identifier: Apache-2.0
 */
 import { CfnCluster } from '@aws-cdk/aws-dax';
 import { CfnResource, Stack } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * DAX clusters have server-side encryption enabled
@@ -15,7 +16,7 @@ export default function (node: CfnResource): boolean {
       return false;
     }
     const sseSpecification = Stack.of(node).resolve(node.sseSpecification);
-    const enabled = Stack.of(node).resolve(sseSpecification.sseEnabled);
+    const enabled = resolveIfPrimitive(node, sseSpecification.sseEnabled);
     if (!enabled) {
       return false;
     }

--- a/src/AwsSolutions/rules/databases/DOC1.ts
+++ b/src/AwsSolutions/rules/databases/DOC1.ts
@@ -3,7 +3,8 @@ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 import { CfnDBCluster } from '@aws-cdk/aws-docdb';
-import { CfnResource, Stack } from '@aws-cdk/core';
+import { CfnResource } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * Document DB clusters have encryption at rest enabled
@@ -14,7 +15,7 @@ export default function (node: CfnResource): boolean {
     if (node.storageEncrypted == undefined) {
       return false;
     }
-    const storageEncrypted = Stack.of(node).resolve(node.storageEncrypted);
+    const storageEncrypted = resolveIfPrimitive(node, node.storageEncrypted);
     if (!storageEncrypted) {
       return false;
     }

--- a/src/AwsSolutions/rules/databases/DOC2.ts
+++ b/src/AwsSolutions/rules/databases/DOC2.ts
@@ -4,6 +4,7 @@ SPDX-License-Identifier: Apache-2.0
 */
 import { CfnDBCluster } from '@aws-cdk/aws-docdb';
 import { CfnResource } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * Document DB clusters do not use the default endpoint port
@@ -11,7 +12,8 @@ import { CfnResource } from '@aws-cdk/core';
  */
 export default function (node: CfnResource): boolean {
   if (node instanceof CfnDBCluster) {
-    if (node.port == undefined || node.port == 27017) {
+    const port = resolveIfPrimitive(node, node.port);
+    if (port == undefined || port == 27017) {
       return false;
     }
   }

--- a/src/AwsSolutions/rules/databases/DOC3.ts
+++ b/src/AwsSolutions/rules/databases/DOC3.ts
@@ -3,7 +3,8 @@ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 import { CfnDBCluster } from '@aws-cdk/aws-docdb';
-import { CfnResource, Stack } from '@aws-cdk/core';
+import { CfnResource } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * Document DB clusters have the username and password stored in Secrets Manager
@@ -11,8 +12,11 @@ import { CfnResource, Stack } from '@aws-cdk/core';
  */
 export default function (node: CfnResource): boolean {
   if (node instanceof CfnDBCluster) {
-    const masterUsername = Stack.of(node).resolve(node.masterUsername);
-    const masterUserPassword = Stack.of(node).resolve(node.masterUserPassword);
+    const masterUsername = resolveIfPrimitive(node, node.masterUsername);
+    const masterUserPassword = resolveIfPrimitive(
+      node,
+      node.masterUserPassword
+    );
     if (
       masterUsername.includes('{{resolve:secretsmanager') == false ||
       masterUserPassword.includes('{{resolve:secretsmanager') == false

--- a/src/AwsSolutions/rules/databases/DOC4.ts
+++ b/src/AwsSolutions/rules/databases/DOC4.ts
@@ -4,6 +4,7 @@ SPDX-License-Identifier: Apache-2.0
 */
 import { CfnDBCluster } from '@aws-cdk/aws-docdb';
 import { CfnResource } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * Document DB clusters have a reasonable minimum backup retention period configured
@@ -11,10 +12,11 @@ import { CfnResource } from '@aws-cdk/core';
  */
 export default function (node: CfnResource): boolean {
   if (node instanceof CfnDBCluster) {
-    if (
-      node.backupRetentionPeriod == undefined ||
-      node.backupRetentionPeriod < 7
-    ) {
+    const backupRetentionPeriod = resolveIfPrimitive(
+      node,
+      node.backupRetentionPeriod
+    );
+    if (backupRetentionPeriod == undefined || backupRetentionPeriod < 7) {
       return false;
     }
   }

--- a/src/AwsSolutions/rules/databases/N2.ts
+++ b/src/AwsSolutions/rules/databases/N2.ts
@@ -3,7 +3,8 @@ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 import { CfnDBInstance } from '@aws-cdk/aws-neptune';
-import { CfnResource, Stack } from '@aws-cdk/core';
+import { CfnResource } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * Neptune DB instances have Auto Minor Version Upgrade enabled
@@ -14,7 +15,8 @@ export default function (node: CfnResource): boolean {
     if (node.autoMinorVersionUpgrade == undefined) {
       return false;
     }
-    const autoMinorVersionUpgrade = Stack.of(node).resolve(
+    const autoMinorVersionUpgrade = resolveIfPrimitive(
+      node,
       node.autoMinorVersionUpgrade
     );
     if (!autoMinorVersionUpgrade) {

--- a/src/AwsSolutions/rules/databases/N3.ts
+++ b/src/AwsSolutions/rules/databases/N3.ts
@@ -4,6 +4,7 @@ SPDX-License-Identifier: Apache-2.0
 */
 import { CfnDBCluster } from '@aws-cdk/aws-neptune';
 import { CfnResource } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../..';
 
 /**
  * Neptune DB clusters have a reasonable minimum backup retention period configured
@@ -11,10 +12,11 @@ import { CfnResource } from '@aws-cdk/core';
  */
 export default function (node: CfnResource): boolean {
   if (node instanceof CfnDBCluster) {
-    if (
-      node.backupRetentionPeriod == undefined ||
-      node.backupRetentionPeriod < 7
-    ) {
+    const backupRetentionPeriod = resolveIfPrimitive(
+      node,
+      node.backupRetentionPeriod
+    );
+    if (backupRetentionPeriod == undefined || backupRetentionPeriod < 7) {
       return false;
     }
   }

--- a/src/AwsSolutions/rules/databases/N4.ts
+++ b/src/AwsSolutions/rules/databases/N4.ts
@@ -3,7 +3,8 @@ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 import { CfnDBCluster } from '@aws-cdk/aws-neptune';
-import { CfnResource, Stack } from '@aws-cdk/core';
+import { CfnResource } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * Neptune DB clusters have encryption at rest enabled
@@ -14,7 +15,7 @@ export default function (node: CfnResource): boolean {
     if (node.storageEncrypted == undefined) {
       return false;
     }
-    const storageEncrypted = Stack.of(node).resolve(node.storageEncrypted);
+    const storageEncrypted = resolveIfPrimitive(node, node.storageEncrypted);
     if (!storageEncrypted) {
       return false;
     }

--- a/src/AwsSolutions/rules/databases/N5.ts
+++ b/src/AwsSolutions/rules/databases/N5.ts
@@ -3,7 +3,8 @@ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 import { CfnDBCluster } from '@aws-cdk/aws-neptune';
-import { CfnResource, Stack } from '@aws-cdk/core';
+import { CfnResource } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * Neptune DB clusters have IAM Database Authentication enabled
@@ -14,7 +15,7 @@ export default function (node: CfnResource): boolean {
     if (node.iamAuthEnabled == undefined) {
       return false;
     }
-    const iamAuthEnabled = Stack.of(node).resolve(node.iamAuthEnabled);
+    const iamAuthEnabled = resolveIfPrimitive(node, node.iamAuthEnabled);
     if (!iamAuthEnabled) {
       return false;
     }

--- a/src/AwsSolutions/rules/databases/RDS10.ts
+++ b/src/AwsSolutions/rules/databases/RDS10.ts
@@ -3,7 +3,8 @@ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 import { CfnDBCluster, CfnDBInstance } from '@aws-cdk/aws-rds';
-import { CfnResource, Stack } from '@aws-cdk/core';
+import { CfnResource } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  *  RDS DB instances and Aurora DB clusters have Deletion Protection enabled
@@ -14,17 +15,23 @@ export default function (node: CfnResource): boolean {
     if (node.deletionProtection == undefined) {
       return false;
     }
-    const deletionProtection = Stack.of(node).resolve(node.deletionProtection);
+    const deletionProtection = resolveIfPrimitive(
+      node,
+      node.deletionProtection
+    );
     if (deletionProtection == false) {
       return false;
     }
     return true;
   } else if (node instanceof CfnDBInstance) {
-    const deletionProtection = Stack.of(node).resolve(node.deletionProtection);
+    const deletionProtection = resolveIfPrimitive(
+      node,
+      node.deletionProtection
+    );
+    const engine = resolveIfPrimitive(node, node.engine);
     if (
       (deletionProtection == false || deletionProtection == undefined) &&
-      (node.engine == undefined ||
-        !node.engine.toLowerCase().includes('aurora'))
+      (engine == undefined || !engine.toLowerCase().includes('aurora'))
     ) {
       return false;
     }

--- a/src/AwsSolutions/rules/databases/RDS11.ts
+++ b/src/AwsSolutions/rules/databases/RDS11.ts
@@ -3,7 +3,8 @@ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 import { CfnDBCluster, CfnDBInstance } from '@aws-cdk/aws-rds';
-import { CfnResource, Stack } from '@aws-cdk/core';
+import { CfnResource } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  *  RDS DB instances and Aurora DB clusters do not use the default endpoint ports
@@ -14,12 +15,10 @@ export default function (node: CfnResource): boolean {
     if (node.port == undefined) {
       return false;
     }
-    const port = Stack.of(node).resolve(node.port);
-    const engine = node.engine.toLowerCase();
-    if (
-      node.engineMode == undefined ||
-      node.engineMode.toLowerCase() == 'provisioned'
-    ) {
+    const port = resolveIfPrimitive(node, node.port);
+    const engine = resolveIfPrimitive(node, node.engine).toLowerCase();
+    const engineMode = resolveIfPrimitive(node, node.engineMode);
+    if (engineMode == undefined || engineMode.toLowerCase() == 'provisioned') {
       if (engine.includes('aurora') && port == 3306) {
         return false;
       }
@@ -36,8 +35,8 @@ export default function (node: CfnResource): boolean {
     if (node.engine == undefined) {
       return false;
     }
-    const port = Stack.of(node).resolve(node.port);
-    const engine = node.engine.toLowerCase();
+    const port = resolveIfPrimitive(node, node.port);
+    const engine = resolveIfPrimitive(node, node.engine).toLowerCase();
     if (port == undefined) {
       if (!engine.includes('aurora')) {
         return false;

--- a/src/AwsSolutions/rules/databases/RDS13.ts
+++ b/src/AwsSolutions/rules/databases/RDS13.ts
@@ -3,7 +3,8 @@ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 import { CfnDBInstance } from '@aws-cdk/aws-rds';
-import { CfnResource, Stack } from '@aws-cdk/core';
+import { CfnResource } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  *  RDS DB instances and are configured for automated backups
@@ -11,7 +12,8 @@ import { CfnResource, Stack } from '@aws-cdk/core';
  */
 export default function (node: CfnResource): boolean {
   if (node instanceof CfnDBInstance) {
-    const backupRetentionPeriod = Stack.of(node).resolve(
+    const backupRetentionPeriod = resolveIfPrimitive(
+      node,
       node.backupRetentionPeriod
     );
     if (!(backupRetentionPeriod == undefined || backupRetentionPeriod > 0)) {

--- a/src/AwsSolutions/rules/databases/RDS14.ts
+++ b/src/AwsSolutions/rules/databases/RDS14.ts
@@ -4,6 +4,7 @@ SPDX-License-Identifier: Apache-2.0
 */
 import { CfnDBCluster } from '@aws-cdk/aws-rds';
 import { CfnResource } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * RDS Aurora serverless clusters have Log Exports enabled
@@ -11,9 +12,10 @@ import { CfnResource } from '@aws-cdk/core';
  */
 export default function (node: CfnResource): boolean {
   if (node instanceof CfnDBCluster) {
-    const engine = node.engine.toLowerCase();
+    const engine = resolveIfPrimitive(node, node.engine).toLowerCase();
+    const backtrackWindow = resolveIfPrimitive(node, node.backtrackWindow);
     if (engine == 'aurora' || engine == 'aurora-mysql') {
-      if (node.backtrackWindow == undefined || node.backtrackWindow == 0) {
+      if (backtrackWindow == undefined || backtrackWindow == 0) {
         return false;
       }
     }

--- a/src/AwsSolutions/rules/databases/RDS16.ts
+++ b/src/AwsSolutions/rules/databases/RDS16.ts
@@ -4,6 +4,7 @@ SPDX-License-Identifier: Apache-2.0
 */
 import { CfnDBCluster } from '@aws-cdk/aws-rds';
 import { CfnResource } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * RDS Aurora MySQL serverless clusters have audit, error, general, and slowquery Log Exports enabled
@@ -11,11 +12,13 @@ import { CfnResource } from '@aws-cdk/core';
  */
 export default function (node: CfnResource): boolean {
   if (node instanceof CfnDBCluster) {
+    const engine = resolveIfPrimitive(node, node.engine).toLowerCase();
+    const engineMode = resolveIfPrimitive(node, node.engineMode).toLowerCase();
     if (
-      node.engineMode != undefined &&
-      node.engineMode.toLowerCase() == 'serverless' &&
-      (node.engine.toLowerCase() == 'aurora' ||
-        node.engine.toLowerCase() == 'aurora-mysql')
+      engineMode != undefined &&
+      engineMode.toLowerCase() == 'serverless' &&
+      (engine.toLowerCase() == 'aurora' ||
+        engine.toLowerCase() == 'aurora-mysql')
     ) {
       if (node.enableCloudwatchLogsExports == undefined) {
         return false;

--- a/src/AwsSolutions/rules/databases/RDS2.ts
+++ b/src/AwsSolutions/rules/databases/RDS2.ts
@@ -3,7 +3,8 @@ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 import { CfnDBCluster, CfnDBInstance } from '@aws-cdk/aws-rds';
-import { CfnResource, Stack } from '@aws-cdk/core';
+import { CfnResource } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * RDS DB instances and Aurora DB clusters have storage encryption enabled
@@ -14,13 +15,12 @@ export default function (node: CfnResource): boolean {
     if (node.storageEncrypted == undefined) {
       return false;
     }
-    const encrypted = Stack.of(node).resolve(node.storageEncrypted);
+    const encrypted = resolveIfPrimitive(node, node.storageEncrypted);
     if (encrypted == false) {
       return false;
     }
-    return true;
   } else if (node instanceof CfnDBInstance) {
-    const encrypted = Stack.of(node).resolve(node.storageEncrypted);
+    const encrypted = resolveIfPrimitive(node, node.storageEncrypted);
     if (
       (encrypted == false || encrypted == undefined) &&
       (node.engine == undefined ||
@@ -28,7 +28,6 @@ export default function (node: CfnResource): boolean {
     ) {
       return false;
     }
-    return true;
   }
   return true;
 }

--- a/src/AwsSolutions/rules/databases/RDS6.ts
+++ b/src/AwsSolutions/rules/databases/RDS6.ts
@@ -3,7 +3,8 @@ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 import { CfnDBCluster } from '@aws-cdk/aws-rds';
-import { CfnResource, Stack } from '@aws-cdk/core';
+import { CfnResource } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * RDS Aurora MySQL/PostgresSQL clusters have IAM Database Authentication enabled
@@ -15,7 +16,8 @@ export default function (node: CfnResource): boolean {
       if (node.enableIamDatabaseAuthentication == undefined) {
         return false;
       }
-      const iamAuth = Stack.of(node).resolve(
+      const iamAuth = resolveIfPrimitive(
+        node,
         node.enableIamDatabaseAuthentication
       );
       if (iamAuth == false) {

--- a/src/AwsSolutions/rules/databases/RS10.ts
+++ b/src/AwsSolutions/rules/databases/RS10.ts
@@ -4,6 +4,7 @@ SPDX-License-Identifier: Apache-2.0
 */
 import { CfnCluster } from '@aws-cdk/aws-redshift';
 import { CfnResource } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * Redshift clusters have a retention period for automated snapshots configured
@@ -11,9 +12,13 @@ import { CfnResource } from '@aws-cdk/core';
  */
 export default function (node: CfnResource): boolean {
   if (node instanceof CfnCluster) {
+    const automatedSnapshotRetentionPeriod = resolveIfPrimitive(
+      node,
+      node.automatedSnapshotRetentionPeriod
+    );
     if (
-      node.automatedSnapshotRetentionPeriod != undefined &&
-      node.automatedSnapshotRetentionPeriod == 0
+      automatedSnapshotRetentionPeriod != undefined &&
+      automatedSnapshotRetentionPeriod == 0
     ) {
       return false;
     }

--- a/src/AwsSolutions/rules/databases/RS3.ts
+++ b/src/AwsSolutions/rules/databases/RS3.ts
@@ -4,6 +4,7 @@ SPDX-License-Identifier: Apache-2.0
 */
 import { CfnCluster } from '@aws-cdk/aws-redshift';
 import { CfnResource } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * Redshift clusters use custom user names vice the default (awsuser)
@@ -11,7 +12,8 @@ import { CfnResource } from '@aws-cdk/core';
  */
 export default function (node: CfnResource): boolean {
   if (node instanceof CfnCluster) {
-    if (node.masterUsername == 'awsuser') {
+    const masterUsername = resolveIfPrimitive(node, node.masterUsername);
+    if (masterUsername == 'awsuser') {
       return false;
     }
   }

--- a/src/AwsSolutions/rules/databases/RS4.ts
+++ b/src/AwsSolutions/rules/databases/RS4.ts
@@ -4,6 +4,7 @@ SPDX-License-Identifier: Apache-2.0
 */
 import { CfnCluster } from '@aws-cdk/aws-redshift';
 import { CfnResource } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * Redshift clusters do not use the default endpoint port
@@ -11,7 +12,8 @@ import { CfnResource } from '@aws-cdk/core';
  */
 export default function (node: CfnResource): boolean {
   if (node instanceof CfnCluster) {
-    if (node.port == undefined || node.port == 5439) {
+    const port = resolveIfPrimitive(node, node.port);
+    if (port == undefined || port == 5439) {
       return false;
     }
   }

--- a/src/AwsSolutions/rules/databases/RS6.ts
+++ b/src/AwsSolutions/rules/databases/RS6.ts
@@ -3,7 +3,8 @@ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 import { CfnCluster } from '@aws-cdk/aws-redshift';
-import { CfnResource, Stack } from '@aws-cdk/core';
+import { CfnResource } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * Redshift clusters have encryption at rest enabled
@@ -14,7 +15,7 @@ export default function (node: CfnResource): boolean {
     if (node.encrypted == undefined) {
       return false;
     }
-    const encrypted = Stack.of(node).resolve(node.encrypted);
+    const encrypted = resolveIfPrimitive(node, node.encrypted);
     if (!encrypted) {
       return false;
     }

--- a/src/AwsSolutions/rules/databases/RS8.ts
+++ b/src/AwsSolutions/rules/databases/RS8.ts
@@ -3,7 +3,8 @@ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 import { CfnCluster } from '@aws-cdk/aws-redshift';
-import { CfnResource, Stack } from '@aws-cdk/core';
+import { CfnResource } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * Redshift clusters are not publicly accessible
@@ -11,7 +12,10 @@ import { CfnResource, Stack } from '@aws-cdk/core';
  */
 export default function (node: CfnResource): boolean {
   if (node instanceof CfnCluster) {
-    const publiclyAccessible = Stack.of(node).resolve(node.publiclyAccessible);
+    const publiclyAccessible = resolveIfPrimitive(
+      node,
+      node.publiclyAccessible
+    );
     if (publiclyAccessible === true) {
       return false;
     }

--- a/src/AwsSolutions/rules/databases/RS9.ts
+++ b/src/AwsSolutions/rules/databases/RS9.ts
@@ -3,7 +3,8 @@ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 import { CfnCluster } from '@aws-cdk/aws-redshift';
-import { CfnResource, Stack } from '@aws-cdk/core';
+import { CfnResource } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * Redshift clusters have version upgrade enabled
@@ -11,7 +12,8 @@ import { CfnResource, Stack } from '@aws-cdk/core';
  */
 export default function (node: CfnResource): boolean {
   if (node instanceof CfnCluster) {
-    const allowVersionUpgrade = Stack.of(node).resolve(
+    const allowVersionUpgrade = resolveIfPrimitive(
+      node,
       node.allowVersionUpgrade
     );
     if (allowVersionUpgrade === false) {

--- a/src/AwsSolutions/rules/developer_tools/C91.ts
+++ b/src/AwsSolutions/rules/developer_tools/C91.ts
@@ -3,7 +3,8 @@ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 import { CfnEnvironmentEC2 } from '@aws-cdk/aws-cloud9';
-import { CfnResource, Stack } from '@aws-cdk/core';
+import { CfnResource } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * Cloud9 instances use no-ingress EC2 instances with AWS Systems Manager
@@ -11,7 +12,7 @@ import { CfnResource, Stack } from '@aws-cdk/core';
  */
 export default function (node: CfnResource): boolean {
   if (node instanceof CfnEnvironmentEC2) {
-    const connectionType = Stack.of(node).resolve(node.connectionType);
+    const connectionType = resolveIfPrimitive(node, node.connectionType);
     if (connectionType == undefined || connectionType != 'CONNECT_SSM') {
       return false;
     }

--- a/src/AwsSolutions/rules/developer_tools/CB3.ts
+++ b/src/AwsSolutions/rules/developer_tools/CB3.ts
@@ -4,6 +4,7 @@ SPDX-License-Identifier: Apache-2.0
 */
 import { CfnProject } from '@aws-cdk/aws-codebuild';
 import { CfnResource, Stack } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * Codebuild projects have privileged mode disabled
@@ -12,7 +13,7 @@ import { CfnResource, Stack } from '@aws-cdk/core';
 export default function (node: CfnResource): boolean {
   if (node instanceof CfnProject) {
     const environment = Stack.of(node).resolve(node.environment);
-    const privilegedMode = Stack.of(node).resolve(environment.privilegedMode);
+    const privilegedMode = resolveIfPrimitive(node, environment.privilegedMode);
     if (privilegedMode != undefined && privilegedMode) {
       return false;
     }

--- a/src/AwsSolutions/rules/developer_tools/CB4.ts
+++ b/src/AwsSolutions/rules/developer_tools/CB4.ts
@@ -3,7 +3,8 @@ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 import { CfnProject } from '@aws-cdk/aws-codebuild';
-import { CfnResource, Stack } from '@aws-cdk/core';
+import { CfnResource } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * Codebuild projects use an AWS KMS key for encryption
@@ -11,7 +12,7 @@ import { CfnResource, Stack } from '@aws-cdk/core';
  */
 export default function (node: CfnResource): boolean {
   if (node instanceof CfnProject) {
-    const encryptionKey = Stack.of(node).resolve(node.encryptionKey);
+    const encryptionKey = resolveIfPrimitive(node, node.encryptionKey);
     if (encryptionKey == undefined || encryptionKey == 'alias/aws/s3') {
       return false;
     }

--- a/src/AwsSolutions/rules/developer_tools/CB5.ts
+++ b/src/AwsSolutions/rules/developer_tools/CB5.ts
@@ -4,6 +4,7 @@ SPDX-License-Identifier: Apache-2.0
 */
 import { CfnProject } from '@aws-cdk/aws-codebuild';
 import { CfnResource, Stack } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * Codebuild projects use images provided by the CodeBuild service or have a cdk_nag suppression rule explaining the need for a custom image
@@ -12,7 +13,7 @@ import { CfnResource, Stack } from '@aws-cdk/core';
 export default function (node: CfnResource): boolean {
   if (node instanceof CfnProject) {
     const environment = Stack.of(node).resolve(node.environment);
-    const image = <string>Stack.of(node).resolve(environment.image);
+    const image = resolveIfPrimitive(node, environment.image);
     if (!image.startsWith('aws/codebuild/')) {
       return false;
     }

--- a/src/AwsSolutions/rules/machine_learning/SM3.ts
+++ b/src/AwsSolutions/rules/machine_learning/SM3.ts
@@ -3,7 +3,8 @@ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 import { CfnNotebookInstance } from '@aws-cdk/aws-sagemaker';
-import { CfnResource, Stack } from '@aws-cdk/core';
+import { CfnResource } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * SageMaker notebook instances have direct internet access disabled
@@ -11,7 +12,8 @@ import { CfnResource, Stack } from '@aws-cdk/core';
  */
 export default function (node: CfnResource): boolean {
   if (node instanceof CfnNotebookInstance) {
-    const directInternetAccess = Stack.of(node).resolve(
+    const directInternetAccess = resolveIfPrimitive(
+      node,
       node.directInternetAccess
     );
     if (

--- a/src/AwsSolutions/rules/management_and_governance/AS1.ts
+++ b/src/AwsSolutions/rules/management_and_governance/AS1.ts
@@ -3,7 +3,8 @@ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 import { CfnAutoScalingGroup } from '@aws-cdk/aws-autoscaling';
-import { CfnResource, Stack } from '@aws-cdk/core';
+import { CfnResource } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * Auto Scaling Groups have configured cooldown periods
@@ -11,7 +12,7 @@ import { CfnResource, Stack } from '@aws-cdk/core';
  */
 export default function (node: CfnResource): boolean {
   if (node instanceof CfnAutoScalingGroup) {
-    const cooldown = Stack.of(node).resolve(node.cooldown);
+    const cooldown = resolveIfPrimitive(node, node.cooldown);
     if (cooldown != undefined && parseInt(cooldown) == 0) {
       return false;
     }

--- a/src/AwsSolutions/rules/management_and_governance/AS2.ts
+++ b/src/AwsSolutions/rules/management_and_governance/AS2.ts
@@ -3,7 +3,8 @@ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 import { CfnAutoScalingGroup } from '@aws-cdk/aws-autoscaling';
-import { CfnResource, Stack } from '@aws-cdk/core';
+import { CfnResource } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * Auto Scaling Groups have properly configured health checks
@@ -11,8 +12,9 @@ import { CfnResource, Stack } from '@aws-cdk/core';
  */
 export default function (node: CfnResource): boolean {
   if (node instanceof CfnAutoScalingGroup) {
-    const healthCheckType = Stack.of(node).resolve(node.healthCheckType);
-    const healthCheckGracePeriod = Stack.of(node).resolve(
+    const healthCheckType = resolveIfPrimitive(node, node.healthCheckType);
+    const healthCheckGracePeriod = resolveIfPrimitive(
+      node,
       node.healthCheckGracePeriod
     );
     if (

--- a/src/AwsSolutions/rules/media_services/MS1.ts
+++ b/src/AwsSolutions/rules/media_services/MS1.ts
@@ -3,7 +3,8 @@ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 import { CfnContainer } from '@aws-cdk/aws-mediastore';
-import { CfnResource, Stack } from '@aws-cdk/core';
+import { CfnResource } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * Media Store containers have container access logging enabled
@@ -11,10 +12,11 @@ import { CfnResource, Stack } from '@aws-cdk/core';
  */
 export default function (node: CfnResource): boolean {
   if (node instanceof CfnContainer) {
-    const accessLoggingEnabled = Stack.of(node).resolve(
+    const accessLoggingEnabled = resolveIfPrimitive(
+      node,
       node.accessLoggingEnabled
     );
-    if (accessLoggingEnabled == undefined || !accessLoggingEnabled) {
+    if (accessLoggingEnabled !== true) {
       return false;
     }
   }

--- a/src/AwsSolutions/rules/media_services/MS4.ts
+++ b/src/AwsSolutions/rules/media_services/MS4.ts
@@ -4,6 +4,7 @@ SPDX-License-Identifier: Apache-2.0
 */
 import { CfnContainer } from '@aws-cdk/aws-mediastore';
 import { CfnResource, Stack } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * Media Store containers define metric policies to send metrics to CloudWatch
@@ -15,7 +16,8 @@ export default function (node: CfnResource): boolean {
     if (metricPolicy == undefined) {
       return false;
     }
-    const containerLevelMetrics = Stack.of(node).resolve(
+    const containerLevelMetrics = resolveIfPrimitive(
+      node,
       metricPolicy.containerLevelMetrics
     );
     if (containerLevelMetrics != 'ENABLED') {

--- a/src/AwsSolutions/rules/network_and_delivery/APIG4.ts
+++ b/src/AwsSolutions/rules/network_and_delivery/APIG4.ts
@@ -4,7 +4,8 @@ SPDX-License-Identifier: Apache-2.0
 */
 import { AuthorizationType, CfnMethod } from '@aws-cdk/aws-apigateway';
 import { CfnRoute } from '@aws-cdk/aws-apigatewayv2';
-import { CfnResource, Stack } from '@aws-cdk/core';
+import { CfnResource } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * APIs implement authorization
@@ -12,9 +13,10 @@ import { CfnResource, Stack } from '@aws-cdk/core';
  */
 export default function (node: CfnResource): boolean {
   if (node instanceof CfnMethod || node instanceof CfnRoute) {
+    const authorizationType = resolveIfPrimitive(node, node.authorizationType);
     if (
-      node.authorizationType == undefined ||
-      Stack.of(node).resolve(node.authorizationType) == AuthorizationType.NONE
+      authorizationType == undefined ||
+      authorizationType == AuthorizationType.NONE
     ) {
       return false;
     }

--- a/src/AwsSolutions/rules/network_and_delivery/CFR1.ts
+++ b/src/AwsSolutions/rules/network_and_delivery/CFR1.ts
@@ -4,6 +4,7 @@ SPDX-License-Identifier: Apache-2.0
 */
 import { CfnDistribution } from '@aws-cdk/aws-cloudfront';
 import { CfnResource, Stack } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * CloudFront distributions may require Geo restrictions
@@ -21,7 +22,11 @@ export default function (node: CfnResource): boolean {
       const geoRestrictions = Stack.of(node).resolve(
         restrictions.geoRestriction
       );
-      if (geoRestrictions.restrictionType == 'none') {
+      const restrictionType = resolveIfPrimitive(
+        node,
+        geoRestrictions.restrictionType
+      );
+      if (restrictionType == 'none') {
         return false;
       }
     }

--- a/src/AwsSolutions/rules/network_and_delivery/CFR3.ts
+++ b/src/AwsSolutions/rules/network_and_delivery/CFR3.ts
@@ -7,6 +7,7 @@ import {
   CfnStreamingDistribution,
 } from '@aws-cdk/aws-cloudfront';
 import { CfnResource, Stack } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * CloudFront distributions have access logging enabled
@@ -26,7 +27,7 @@ export default function (node: CfnResource): boolean {
       return false;
     }
     const logging = Stack.of(node).resolve(distributionConfig.logging);
-    const enabled = Stack.of(node).resolve(logging.enabled);
+    const enabled = resolveIfPrimitive(node, logging.enabled);
     if (!enabled) {
       return false;
     }

--- a/src/AwsSolutions/rules/network_and_delivery/CFR5.ts
+++ b/src/AwsSolutions/rules/network_and_delivery/CFR5.ts
@@ -8,6 +8,7 @@ import {
   SecurityPolicyProtocol,
 } from '@aws-cdk/aws-cloudfront';
 import { CfnResource, Stack } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * CloudFront distributions do not use SSLv3 or TLSv1 for communication to the origin
@@ -24,10 +25,11 @@ export default function (node: CfnResource): boolean {
           const customOriginConfig = Stack.of(node).resolve(
             resolvedOrigin.customOriginConfig
           );
-          if (
-            customOriginConfig.originProtocolPolicy !=
-            OriginProtocolPolicy.HTTPS_ONLY
-          ) {
+          const originProtocolPolicy = resolveIfPrimitive(
+            node,
+            customOriginConfig.originProtocolPolicy
+          );
+          if (originProtocolPolicy != OriginProtocolPolicy.HTTPS_ONLY) {
             return false;
           }
           if (customOriginConfig.originSslProtocols == undefined) {

--- a/src/AwsSolutions/rules/security_and_compliance/COG1.ts
+++ b/src/AwsSolutions/rules/security_and_compliance/COG1.ts
@@ -4,6 +4,7 @@ SPDX-License-Identifier: Apache-2.0
 */
 import { CfnUserPool } from '@aws-cdk/aws-cognito';
 import { CfnResource, Stack } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * Cognito user pools have password policies that minimally specify a password length of at least 8 characters, as well as requiring uppercase, numeric, and special characters
@@ -20,29 +21,35 @@ export default function (node: CfnResource): boolean {
       return false;
     }
 
-    const minimumLength = Stack.of(node).resolve(passwordPolicy.minimumLength);
+    const minimumLength = resolveIfPrimitive(
+      node,
+      passwordPolicy.minimumLength
+    );
     if (minimumLength == undefined || minimumLength < 8) {
       return false;
     }
 
-    const requireUppercase = Stack.of(node).resolve(
+    const requireUppercase = resolveIfPrimitive(
+      node,
       passwordPolicy.requireUppercase
     );
-    if (minimumLength == undefined || !requireUppercase) {
+    if (requireUppercase !== true) {
       return false;
     }
 
-    const requireNumbers = Stack.of(node).resolve(
+    const requireNumbers = resolveIfPrimitive(
+      node,
       passwordPolicy.requireNumbers
     );
-    if (requireNumbers == undefined || !requireNumbers) {
+    if (requireNumbers !== true) {
       return false;
     }
 
-    const requireSymbols = Stack.of(node).resolve(
+    const requireSymbols = resolveIfPrimitive(
+      node,
       passwordPolicy.requireSymbols
     );
-    if (requireSymbols == undefined || !requireSymbols) {
+    if (requireSymbols !== true) {
       return false;
     }
   }

--- a/src/AwsSolutions/rules/security_and_compliance/COG2.ts
+++ b/src/AwsSolutions/rules/security_and_compliance/COG2.ts
@@ -3,7 +3,8 @@ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 import { CfnUserPool, Mfa } from '@aws-cdk/aws-cognito';
-import { CfnResource, Stack } from '@aws-cdk/core';
+import { CfnResource } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * Cognito user pools require MFA
@@ -11,7 +12,7 @@ import { CfnResource, Stack } from '@aws-cdk/core';
  */
 export default function (node: CfnResource): boolean {
   if (node instanceof CfnUserPool) {
-    const mfaConfiguration = Stack.of(node).resolve(node.mfaConfiguration);
+    const mfaConfiguration = resolveIfPrimitive(node, node.mfaConfiguration);
     if (mfaConfiguration == undefined || mfaConfiguration != Mfa.REQUIRED) {
       return false;
     }

--- a/src/AwsSolutions/rules/security_and_compliance/COG3.ts
+++ b/src/AwsSolutions/rules/security_and_compliance/COG3.ts
@@ -4,6 +4,7 @@ SPDX-License-Identifier: Apache-2.0
 */
 import { CfnUserPool } from '@aws-cdk/aws-cognito';
 import { CfnResource, Stack } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * Cognito user pools have AdvancedSecurityMode set to ENFORCED
@@ -15,7 +16,8 @@ export default function (node: CfnResource): boolean {
     if (userPoolAddOns == undefined) {
       return false;
     }
-    const advancedSecurityMode = Stack.of(node).resolve(
+    const advancedSecurityMode = resolveIfPrimitive(
+      node,
       userPoolAddOns.advancedSecurityMode
     );
     if (

--- a/src/AwsSolutions/rules/security_and_compliance/COG7.ts
+++ b/src/AwsSolutions/rules/security_and_compliance/COG7.ts
@@ -3,7 +3,8 @@ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 import { CfnIdentityPool } from '@aws-cdk/aws-cognito';
-import { CfnResource, Stack } from '@aws-cdk/core';
+import { CfnResource } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * Cognito identity pools do not allow for unauthenticated logins without a valid reason
@@ -11,7 +12,8 @@ import { CfnResource, Stack } from '@aws-cdk/core';
  */
 export default function (node: CfnResource): boolean {
   if (node instanceof CfnIdentityPool) {
-    const allowUnauthenticatedIdentities = Stack.of(node).resolve(
+    const allowUnauthenticatedIdentities = resolveIfPrimitive(
+      node,
       node.allowUnauthenticatedIdentities
     );
     if (allowUnauthenticatedIdentities) {

--- a/src/AwsSolutions/rules/security_and_compliance/KMS5.ts
+++ b/src/AwsSolutions/rules/security_and_compliance/KMS5.ts
@@ -4,6 +4,7 @@ SPDX-License-Identifier: Apache-2.0
 */
 import { CfnKey, KeySpec } from '@aws-cdk/aws-kms';
 import { CfnResource, Stack } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * KMS Symmetric keys have Key Rotation enabled
@@ -13,8 +14,11 @@ export default function (node: CfnResource): boolean {
   if (node instanceof CfnKey) {
     const keySpec = Stack.of(node).resolve(node.keySpec);
     if (keySpec == undefined || keySpec == KeySpec.SYMMETRIC_DEFAULT) {
-      const enableKeyRotation = Stack.of(node).resolve(node.enableKeyRotation);
-      if (enableKeyRotation == undefined || !enableKeyRotation) {
+      const enableKeyRotation = resolveIfPrimitive(
+        node,
+        node.enableKeyRotation
+      );
+      if (enableKeyRotation !== true) {
         return false;
       }
     }

--- a/src/AwsSolutions/rules/serverless/SF1.ts
+++ b/src/AwsSolutions/rules/serverless/SF1.ts
@@ -4,6 +4,7 @@ SPDX-License-Identifier: Apache-2.0
 */
 import { CfnStateMachine, LogLevel } from '@aws-cdk/aws-stepfunctions';
 import { CfnResource, Stack } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * Step Function log "ALL" events to CloudWatch Logs
@@ -17,7 +18,7 @@ export default function (node: CfnResource): boolean {
     if (loggingConfiguration == undefined) {
       return false;
     }
-    const level = Stack.of(node).resolve(loggingConfiguration.level);
+    const level = resolveIfPrimitive(node, loggingConfiguration.level);
     if (level == undefined || level != LogLevel.ALL) {
       return false;
     }

--- a/src/AwsSolutions/rules/serverless/SF2.ts
+++ b/src/AwsSolutions/rules/serverless/SF2.ts
@@ -4,6 +4,7 @@ SPDX-License-Identifier: Apache-2.0
 */
 import { CfnStateMachine } from '@aws-cdk/aws-stepfunctions';
 import { CfnResource, Stack } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * Step Function have X-Ray tracing enabled
@@ -17,7 +18,7 @@ export default function (node: CfnResource): boolean {
     if (tracingConfiguration == undefined) {
       return false;
     }
-    const enabled = Stack.of(node).resolve(tracingConfiguration.enabled);
+    const enabled = resolveIfPrimitive(node, tracingConfiguration.enabled);
     if (!enabled) {
       return false;
     }

--- a/src/AwsSolutions/rules/storage/EFS1.ts
+++ b/src/AwsSolutions/rules/storage/EFS1.ts
@@ -3,7 +3,8 @@ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 import { CfnFileSystem } from '@aws-cdk/aws-efs';
-import { CfnResource, Stack } from '@aws-cdk/core';
+import { CfnResource } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * Elastic File Systems are configured for encryption at rest.
@@ -14,7 +15,7 @@ export default function (node: CfnResource): boolean {
     if (node.encrypted == undefined) {
       return false;
     }
-    const encrypted = Stack.of(node).resolve(node.encrypted);
+    const encrypted = resolveIfPrimitive(node, node.encrypted);
     if (encrypted == false) {
       return false;
     }

--- a/src/AwsSolutions/rules/storage/S2.ts
+++ b/src/AwsSolutions/rules/storage/S2.ts
@@ -4,6 +4,7 @@ SPDX-License-Identifier: Apache-2.0
 */
 import { CfnBucket } from '@aws-cdk/aws-s3';
 import { CfnResource, Stack } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * S3 Buckets should have public access restricted and blocked.
@@ -17,31 +18,27 @@ export default function (node: CfnResource): boolean {
     const publicAccess = Stack.of(node).resolve(
       node.publicAccessBlockConfiguration
     );
-    if (
-      publicAccess.blockPublicAcls == undefined ||
-      publicAccess.blockPublicPolicy == undefined ||
-      publicAccess.ignorePublicAcls == undefined ||
-      publicAccess.restrictPublicBuckets == undefined
-    ) {
-      return false;
-    }
-    const blockPublicAcls = Stack.of(node).resolve(
+    const blockPublicAcls = resolveIfPrimitive(
+      node,
       publicAccess.blockPublicAcls
     );
-    const blockPublicPolicy = Stack.of(node).resolve(
+    const blockPublicPolicy = resolveIfPrimitive(
+      node,
       publicAccess.blockPublicPolicy
     );
-    const ignorePublicAcls = Stack.of(node).resolve(
+    const ignorePublicAcls = resolveIfPrimitive(
+      node,
       publicAccess.ignorePublicAcls
     );
-    const restrictPublicBuckets = Stack.of(node).resolve(
+    const restrictPublicBuckets = resolveIfPrimitive(
+      node,
       publicAccess.restrictPublicBuckets
     );
     if (
-      blockPublicAcls == false ||
-      blockPublicPolicy == false ||
-      ignorePublicAcls == false ||
-      restrictPublicBuckets == false
+      blockPublicAcls !== true ||
+      blockPublicPolicy !== true ||
+      ignorePublicAcls !== true ||
+      restrictPublicBuckets !== true
     ) {
       return false;
     }

--- a/src/AwsSolutions/rules/storage/S3.ts
+++ b/src/AwsSolutions/rules/storage/S3.ts
@@ -4,6 +4,7 @@ SPDX-License-Identifier: Apache-2.0
 */
 import { CfnBucket } from '@aws-cdk/aws-s3';
 import { CfnResource, Stack } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * S3 Buckets should have default encryption enabled
@@ -27,10 +28,16 @@ export default function (node: CfnResource): boolean {
       const defaultEncryption = Stack.of(node).resolve(
         rule.serverSideEncryptionByDefault
       );
+      if (defaultEncryption == undefined) {
+        return false;
+      }
+      const sseAlgorithm = resolveIfPrimitive(
+        node,
+        defaultEncryption.sseAlgorithm
+      );
       if (
-        defaultEncryption == undefined ||
-        (defaultEncryption.sseAlgorithm.toLowerCase() != 'aes256' &&
-          defaultEncryption.sseAlgorithm.toLowerCase() != 'aws:kms')
+        sseAlgorithm.toLowerCase() != 'aes256' &&
+        sseAlgorithm.toLowerCase() != 'aws:kms'
       ) {
         return false;
       }

--- a/src/HIPAA-Security/rules/apigw/hipaaSecurityAPIGWXrayEnabled.ts
+++ b/src/HIPAA-Security/rules/apigw/hipaaSecurityAPIGWXrayEnabled.ts
@@ -3,15 +3,15 @@ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 import { CfnStage } from '@aws-cdk/aws-apigateway';
-import { CfnResource, Stack } from '@aws-cdk/core';
-
+import { CfnResource } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 /**
  * API Gateway REST API stages have X-Ray tracing enabled - (Control IDs: 164.312(b))
  * @param node the CfnResource to check
  */
 export default function (node: CfnResource): boolean {
   if (node instanceof CfnStage) {
-    const tracingEnabled = Stack.of(node).resolve(node.tracingEnabled);
+    const tracingEnabled = resolveIfPrimitive(node, node.tracingEnabled);
     if (tracingEnabled !== true) {
       return false;
     }

--- a/src/HIPAA-Security/rules/autoscaling/hipaaSecurityAutoscalingGroupELBHealthCheckRequired.ts
+++ b/src/HIPAA-Security/rules/autoscaling/hipaaSecurityAutoscalingGroupELBHealthCheckRequired.ts
@@ -5,7 +5,7 @@ SPDX-License-Identifier: Apache-2.0
 
 import { CfnAutoScalingGroup } from '@aws-cdk/aws-autoscaling';
 import { CfnResource, Stack } from '@aws-cdk/core';
-
+import { resolveIfPrimitive } from '../../../common';
 /**
  * Auto Scaling groups which are associated with load balancers utilize ELB health checks - (Control ID: 164.312(b))
  * @param node the CfnResource to check
@@ -20,7 +20,7 @@ export default function (node: CfnResource): boolean {
       (otherLBs != undefined && otherLBs.length > 0) ||
       (classicLBs != undefined && classicLBs.length > 0)
     ) {
-      const healthCheckType = Stack.of(node).resolve(node.healthCheckType);
+      const healthCheckType = resolveIfPrimitive(node, node.healthCheckType);
       //Do we use ELB health checks?
       if (healthCheckType != undefined) {
         if (healthCheckType != 'ELB') {

--- a/src/HIPAA-Security/rules/autoscaling/hipaaSecurityAutoscalingLaunchConfigPublicIpDisabled.ts
+++ b/src/HIPAA-Security/rules/autoscaling/hipaaSecurityAutoscalingLaunchConfigPublicIpDisabled.ts
@@ -4,15 +4,16 @@ SPDX-License-Identifier: Apache-2.0
 */
 
 import { CfnLaunchConfiguration } from '@aws-cdk/aws-autoscaling';
-import { CfnResource, Stack } from '@aws-cdk/core';
-
+import { CfnResource } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 /**
  * Auto Scaling launch configurations have public IP addresses disabled - (Control IDs: 164.308(a)(3)(i), 164.308(a)(3)(ii)(B), 164.308(a)(4)(ii)(A), 164.308(a)(4)(ii)(C), 164.312(a)(1), 164.312(e)(1))
  * @param node the CfnResource to check
  */
 export default function (node: CfnResource): boolean {
   if (node instanceof CfnLaunchConfiguration) {
-    const associatePublicIpAddress = Stack.of(node).resolve(
+    const associatePublicIpAddress = resolveIfPrimitive(
+      node,
       node.associatePublicIpAddress
     );
     if (associatePublicIpAddress !== false) {

--- a/src/HIPAA-Security/rules/cloudtrail/hipaaSecurityCloudTrailLogFileValidationEnabled.ts
+++ b/src/HIPAA-Security/rules/cloudtrail/hipaaSecurityCloudTrailLogFileValidationEnabled.ts
@@ -3,15 +3,15 @@ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 import { CfnTrail } from '@aws-cdk/aws-cloudtrail';
-import { CfnResource, Stack } from '@aws-cdk/core';
-
+import { CfnResource } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 /**
  * CloudTrail trails have log file validation enabled - (Control ID: 164.312(c)(1), 164.312(c)(2))
  * @param node the CfnResource to check
  */
 export default function (node: CfnResource): boolean {
   if (node instanceof CfnTrail) {
-    const enabled = Stack.of(node).resolve(node.enableLogFileValidation);
+    const enabled = resolveIfPrimitive(node, node.enableLogFileValidation);
 
     if (enabled != true) {
       return false;

--- a/src/HIPAA-Security/rules/codebuild/hipaaSecurityCodeBuildProjectEnvVarAwsCred.ts
+++ b/src/HIPAA-Security/rules/codebuild/hipaaSecurityCodeBuildProjectEnvVarAwsCred.ts
@@ -5,6 +5,7 @@ SPDX-License-Identifier: Apache-2.0
 
 import { CfnProject } from '@aws-cdk/aws-codebuild';
 import { CfnResource, Stack } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * CodeBuild projects do not store AWS credentials as plaintext environment variables - (Control IDs: 164.308(a)(3)(i), 164.308(a)(4)(ii)(A), 164.308(a)(4)(ii)(C), 164.312(a)(1))
@@ -21,15 +22,11 @@ export default function (node: CfnResource): boolean {
       //For each envvar, check if its a sensitive credential being stored
       for (const envVar of environmentVars) {
         const resolvedEnvVar = Stack.of(node).resolve(envVar);
-        if (
-          resolvedEnvVar.name == 'AWS_ACCESS_KEY_ID' ||
-          resolvedEnvVar.name == 'AWS_SECRET_ACCESS_KEY'
-        ) {
+        const name = resolveIfPrimitive(node, resolvedEnvVar.name);
+        const type = resolveIfPrimitive(node, resolvedEnvVar.type);
+        if (name == 'AWS_ACCESS_KEY_ID' || name == 'AWS_SECRET_ACCESS_KEY') {
           //is this credential being stored as plaintext?
-          if (
-            resolvedEnvVar.type == undefined ||
-            resolvedEnvVar.type == 'PLAINTEXT'
-          ) {
+          if (type == undefined || type == 'PLAINTEXT') {
             return false;
           }
         }

--- a/src/HIPAA-Security/rules/codebuild/hipaaSecurityCodeBuildProjectSourceRepoUrl.ts
+++ b/src/HIPAA-Security/rules/codebuild/hipaaSecurityCodeBuildProjectSourceRepoUrl.ts
@@ -5,6 +5,7 @@ SPDX-License-Identifier: Apache-2.0
 
 import { CfnProject } from '@aws-cdk/aws-codebuild';
 import { CfnResource, Stack } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * Codebuild projects with a GitHub or BitBucket source repository utilize OAUTH - (Control IDs: 164.308(a)(3)(i), 164.308(a)(4)(ii)(A), 164.308(a)(4)(ii)(C), 164.312(a)(1))
@@ -18,7 +19,7 @@ export default function (node: CfnResource): boolean {
     if (projectAuth == undefined) {
       return false;
     } else {
-      const projectAuthType = projectAuth.type;
+      const projectAuthType = resolveIfPrimitive(node, projectAuth.type);
       if (projectAuthType != 'OAUTH') {
         return false;
       }

--- a/src/HIPAA-Security/rules/dms/hipaaSecurityDMSReplicationNotPublic.ts
+++ b/src/HIPAA-Security/rules/dms/hipaaSecurityDMSReplicationNotPublic.ts
@@ -3,7 +3,8 @@ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 import { CfnReplicationInstance } from '@aws-cdk/aws-dms';
-import { CfnResource, Stack } from '@aws-cdk/core';
+import { CfnResource } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * DMS replication instances are not public - (Control IDs: 164.308(a)(3)(i), 164.308(a)(4)(ii)(A), 164.308(a)(4)(ii)(C), 164.312(a)(1), 164.312(e)(1))
@@ -11,7 +12,7 @@ import { CfnResource, Stack } from '@aws-cdk/core';
  */
 export default function (node: CfnResource): boolean {
   if (node instanceof CfnReplicationInstance) {
-    const publicAccess = Stack.of(node).resolve(node.publiclyAccessible);
+    const publicAccess = resolveIfPrimitive(node, node.publiclyAccessible);
     if (publicAccess !== false) {
       return false;
     }

--- a/src/HIPAA-Security/rules/dynamodb/hipaaSecurityDynamoDBPITREnabled.ts
+++ b/src/HIPAA-Security/rules/dynamodb/hipaaSecurityDynamoDBPITREnabled.ts
@@ -4,6 +4,7 @@ SPDX-License-Identifier: Apache-2.0
 */
 import { CfnTable } from '@aws-cdk/aws-dynamodb';
 import { CfnResource, Stack } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * DynamoDB tables have Point-in-time Recovery enabled - (Control IDs: 164.308(a)(7)(i), 164.308(a)(7)(ii)(A), 164.308(a)(7)(ii)(B))
@@ -16,7 +17,7 @@ export default function (node: CfnResource): boolean {
       return false;
     }
     const pitr = Stack.of(node).resolve(node.pointInTimeRecoverySpecification);
-    const enabled = Stack.of(node).resolve(pitr.pointInTimeRecoveryEnabled);
+    const enabled = resolveIfPrimitive(node, pitr.pointInTimeRecoveryEnabled);
     if (!enabled) {
       return false;
     }

--- a/src/HIPAA-Security/rules/ec2/hipaaSecurityEC2EBSOptimizedInstance.ts
+++ b/src/HIPAA-Security/rules/ec2/hipaaSecurityEC2EBSOptimizedInstance.ts
@@ -5,6 +5,7 @@ SPDX-License-Identifier: Apache-2.0
 
 import { CfnInstance } from '@aws-cdk/aws-ec2';
 import { CfnResource, Stack } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 const EBS_OPTIMIZED_SUPPORTED = [
   'c1.xlarge',
@@ -33,7 +34,9 @@ const DEFAULT_TYPE = 'm1.small';
  */
 export default function (node: CfnResource): boolean {
   if (node instanceof CfnInstance) {
-    const instanceType = node.instanceType ? node.instanceType : DEFAULT_TYPE;
+    const instanceType = node.instanceType
+      ? resolveIfPrimitive(node, node.instanceType)
+      : DEFAULT_TYPE;
     const ebsOptimized = Stack.of(node).resolve(node.ebsOptimized);
     if (
       EBS_OPTIMIZED_SUPPORTED.includes(instanceType) &&

--- a/src/HIPAA-Security/rules/ec2/hipaaSecurityEC2InstanceDetailedMonitoringEnabled.ts
+++ b/src/HIPAA-Security/rules/ec2/hipaaSecurityEC2InstanceDetailedMonitoringEnabled.ts
@@ -5,7 +5,8 @@ SPDX-License-Identifier: Apache-2.0
 
 import { CfnLaunchConfiguration } from '@aws-cdk/aws-autoscaling';
 import { CfnInstance } from '@aws-cdk/aws-ec2';
-import { CfnResource, Stack } from '@aws-cdk/core';
+import { CfnResource } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * EC2 instances have detailed monitoring enabled - (Control ID: 164.312(b))
@@ -13,12 +14,12 @@ import { CfnResource, Stack } from '@aws-cdk/core';
  */
 export default function (node: CfnResource): boolean {
   if (node instanceof CfnInstance) {
-    const monitoring = Stack.of(node).resolve(node.monitoring);
+    const monitoring = resolveIfPrimitive(node, node.monitoring);
     if (monitoring == undefined || monitoring == false) {
       return false;
     }
   } else if (node instanceof CfnLaunchConfiguration) {
-    const monitoring = Stack.of(node).resolve(node.instanceMonitoring);
+    const monitoring = resolveIfPrimitive(node, node.instanceMonitoring);
     if (monitoring != undefined && monitoring == false) {
       return false;
     }

--- a/src/HIPAA-Security/rules/ec2/hipaaSecurityEC2InstanceNoPublicIps.ts
+++ b/src/HIPAA-Security/rules/ec2/hipaaSecurityEC2InstanceNoPublicIps.ts
@@ -5,6 +5,7 @@ SPDX-License-Identifier: Apache-2.0
 
 import { CfnInstance } from '@aws-cdk/aws-ec2';
 import { CfnResource, Stack } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * EC2 instances do not have public IPs - (Control IDs: 164.308(a)(3)(i), 164.308(a)(4)(ii)(A), 164.308(a)(4)(ii)(C), 164.312(a)(1), 164.312(e)(1))
@@ -17,11 +18,11 @@ export default function (node: CfnResource): boolean {
       //Iterate through network interfaces, checking if public IPs are enabled
       for (const networkInterface of networkInterfaces) {
         const resolvedInterface = Stack.of(node).resolve(networkInterface);
-        if (resolvedInterface.associatePublicIpAddress != undefined) {
-          if (resolvedInterface.associatePublicIpAddress == true) {
-            return false;
-          }
-        } else {
+        const associatePublicIpAddress = resolveIfPrimitive(
+          node,
+          resolvedInterface.associatePublicIpAddress
+        );
+        if (associatePublicIpAddress === true) {
           return false;
         }
       }

--- a/src/HIPAA-Security/rules/ec2/hipaaSecurityEC2RestrictedCommonPorts.ts
+++ b/src/HIPAA-Security/rules/ec2/hipaaSecurityEC2RestrictedCommonPorts.ts
@@ -5,6 +5,7 @@ SPDX-License-Identifier: Apache-2.0
 
 import { CfnSecurityGroupIngress, CfnSecurityGroup } from '@aws-cdk/aws-ec2';
 import { CfnResource, Stack } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 const BLOCKED_PORTS = [20, 21, 3389, 3309, 3306, 4333];
 
@@ -21,7 +22,7 @@ export default function (node: CfnResource): boolean {
       for (const rule of ingressRules) {
         const resolvedRule = Stack.of(node).resolve(rule);
         for (const portNum of BLOCKED_PORTS) {
-          if (!testPort(resolvedRule, portNum)) {
+          if (!testPort(node, resolvedRule, portNum)) {
             return false;
           }
         }
@@ -29,7 +30,7 @@ export default function (node: CfnResource): boolean {
     }
   } else if (node instanceof CfnSecurityGroupIngress) {
     for (const portNum of BLOCKED_PORTS) {
-      if (!testPort(node, portNum)) {
+      if (!testPort(node, node, portNum)) {
         return false;
       }
     }
@@ -39,32 +40,41 @@ export default function (node: CfnResource): boolean {
 
 /**
  * Helper function to identify if the given port number is unrestricted
+ * @param node the CfnResource to check
  * @param rule the CfnSecurityGroupIngress rule to check
  * @param portNum the number of the port to check
  */
-function testPort(rule: CfnSecurityGroupIngress, portNum: Number): boolean {
+function testPort(
+  node: CfnResource,
+  rule: CfnSecurityGroupIngress,
+  portNum: Number
+): boolean {
   //Does this rule apply to TCP traffic?
-  if (rule.ipProtocol != undefined && rule.ipProtocol == 'tcp') {
+  const ipProtocol = resolveIfPrimitive(node, rule.ipProtocol);
+  const cidrIp = resolveIfPrimitive(node, rule.cidrIp);
+  const fromPort = resolveIfPrimitive(node, rule.fromPort);
+  const toPort = resolveIfPrimitive(node, rule.toPort);
+  if (ipProtocol === 'tcp') {
     //Does this rule allow all IPv4 addresses (unrestricted access)?
-    if (rule.cidrIp != undefined && rule.cidrIp.includes('/0')) {
+    if (cidrIp != undefined && cidrIp.includes('/0')) {
       //Is a port range specified?
-      if (rule.fromPort != undefined && rule.toPort != undefined) {
+      if (fromPort != undefined && toPort != undefined) {
         if (
-          (rule.fromPort <= portNum && rule.toPort >= portNum) ||
-          rule.fromPort == -1 ||
-          rule.toPort == -1
+          (fromPort <= portNum && toPort >= portNum) ||
+          fromPort == -1 ||
+          toPort == -1
         ) {
           return false;
         }
       } else {
-        if (rule.fromPort == portNum) {
+        if (fromPort == portNum) {
           return false;
         }
       }
     }
   }
   //Are all ports allowed?
-  if (rule.ipProtocol != undefined && rule.ipProtocol == '-1') {
+  if (ipProtocol === '-1') {
     return false;
   }
   return true;

--- a/src/HIPAA-Security/rules/ec2/hipaaSecurityEC2RestrictedSSH.ts
+++ b/src/HIPAA-Security/rules/ec2/hipaaSecurityEC2RestrictedSSH.ts
@@ -5,6 +5,7 @@ SPDX-License-Identifier: Apache-2.0
 
 import { CfnSecurityGroupIngress, CfnSecurityGroup } from '@aws-cdk/aws-ec2';
 import { CfnResource, Stack } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * Security Groups do not allow for unrestricted SSH traffic - (Control IDs: 164.308(a)(3)(i), 164.308(a)(3)(ii)(B), 164.308(a)(4)(i), 164.308(a)(4)(ii)(A), 164.308(a)(4)(ii)(B), 164.308(a)(4)(ii)(C), 164.312(a)(1), 164.312(e)(1))
@@ -17,29 +18,26 @@ export default function (node: CfnResource): boolean {
       //For each ingress rule, ensure that it does not allow unrestricted SSH traffic.
       for (const rule of ingressRules) {
         const resolvedRule = Stack.of(node).resolve(rule);
+        const ipProtocol = resolveIfPrimitive(node, resolvedRule.ipProtocol);
+        const cidrIp = resolveIfPrimitive(node, resolvedRule.cidrIp);
+        const cidrIpv6 = resolveIfPrimitive(node, resolvedRule.cidrIpv6);
+        const fromPort = resolveIfPrimitive(node, resolvedRule.fromPort);
+        const toPort = resolveIfPrimitive(node, resolvedRule.toPort);
         if (
-          (resolvedRule.cidrIp != undefined &&
-            resolvedRule.cidrIp.includes('/0')) ||
-          (resolvedRule.cidrIpv6 != undefined &&
-            resolvedRule.cidrIpv6.includes('/0'))
+          (cidrIp != undefined && cidrIp.includes('/0')) ||
+          (cidrIpv6 != undefined && cidrIpv6.includes('/0'))
         ) {
-          if (
-            resolvedRule.fromPort != undefined &&
-            resolvedRule.toPort != undefined
-          ) {
+          if (fromPort != undefined && toPort != undefined) {
             if (
-              (resolvedRule.fromPort <= 22 && resolvedRule.toPort >= 22) ||
-              resolvedRule.fromPort == -1 ||
-              resolvedRule.toPort == -1 ||
-              resolvedRule.ipProtocol == '-1'
+              (fromPort <= 22 && toPort >= 22) ||
+              fromPort == -1 ||
+              toPort == -1 ||
+              ipProtocol == '-1'
             ) {
               return false;
             }
           } else {
-            if (
-              resolvedRule.fromPort == 22 ||
-              resolvedRule.ipProtocol == '-1'
-            ) {
+            if (fromPort == 22 || ipProtocol == '-1') {
               return false;
             }
           }
@@ -47,22 +45,27 @@ export default function (node: CfnResource): boolean {
       }
     }
   } else if (node instanceof CfnSecurityGroupIngress) {
+    const ipProtocol = resolveIfPrimitive(node, node.ipProtocol);
+    const cidrIp = resolveIfPrimitive(node, node.cidrIp);
+    const cidrIpv6 = resolveIfPrimitive(node, node.cidrIpv6);
+    const fromPort = resolveIfPrimitive(node, node.fromPort);
+    const toPort = resolveIfPrimitive(node, node.toPort);
     if (
-      (node.cidrIp != undefined && node.cidrIp.includes('/0')) ||
-      (node.cidrIpv6 != undefined && node.cidrIpv6.includes('/0'))
+      (cidrIp != undefined && cidrIp.includes('/0')) ||
+      (cidrIpv6 != undefined && cidrIpv6.includes('/0'))
     ) {
       //Is a port range specified?
-      if (node.fromPort != undefined && node.toPort != undefined) {
+      if (fromPort != undefined && toPort != undefined) {
         if (
-          (node.fromPort <= 22 && node.toPort >= 22) ||
-          node.fromPort == -1 ||
-          node.toPort == -1 ||
-          node.ipProtocol == '-1'
+          (fromPort <= 22 && toPort >= 22) ||
+          fromPort == -1 ||
+          toPort == -1 ||
+          ipProtocol == '-1'
         ) {
           return false;
         }
       } else {
-        if (node.fromPort == 22 || node.ipProtocol == '-1') {
+        if (fromPort == 22 || ipProtocol == '-1') {
           return false;
         }
       }

--- a/src/HIPAA-Security/rules/ecs/hipaaSecurityECSTaskDefinitionUserForHostMode.ts
+++ b/src/HIPAA-Security/rules/ecs/hipaaSecurityECSTaskDefinitionUserForHostMode.ts
@@ -4,6 +4,7 @@ SPDX-License-Identifier: Apache-2.0
 */
 import { CfnTaskDefinition, NetworkMode } from '@aws-cdk/aws-ecs';
 import { CfnResource, Stack } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * Containers in ECS task definitions configured for host networking have 'privileged' set to true and a non-empty non-root 'user' - (Control IDs: 164.308(a)(3)(i), 164.308(a)(3)(ii)(A), 164.308(a)(4)(ii)(A), 164.308(a)(4)(ii)(C), 164.312(a)(1))
@@ -19,10 +20,11 @@ export default function (node: CfnResource): boolean {
         for (const containerDefinition of containerDefinitions) {
           const resolvedDefinition =
             Stack.of(node).resolve(containerDefinition);
-          const privileged = Stack.of(node).resolve(
+          const privileged = resolveIfPrimitive(
+            node,
             resolvedDefinition.privileged
           );
-          const user = Stack.of(node).resolve(resolvedDefinition.user);
+          const user = resolveIfPrimitive(node, resolvedDefinition.user);
           if (privileged !== true || user === undefined) {
             return false;
           }

--- a/src/HIPAA-Security/rules/efs/hipaaSecurityEFSEncrypted.ts
+++ b/src/HIPAA-Security/rules/efs/hipaaSecurityEFSEncrypted.ts
@@ -3,7 +3,8 @@ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 import { CfnFileSystem } from '@aws-cdk/aws-efs';
-import { CfnResource, Stack } from '@aws-cdk/core';
+import { CfnResource } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * Elastic File Systems are configured for encryption at rest - (Control IDs: 164.312(a)(2)(iv), 164.312(e)(2)(ii))
@@ -11,7 +12,7 @@ import { CfnResource, Stack } from '@aws-cdk/core';
  */
 export default function (node: CfnResource): boolean {
   if (node instanceof CfnFileSystem) {
-    const encrypted = Stack.of(node).resolve(node.encrypted);
+    const encrypted = resolveIfPrimitive(node, node.encrypted);
     if (encrypted === false) {
       return false;
     }

--- a/src/HIPAA-Security/rules/elasticache/hipaaSecurityElastiCacheRedisClusterAutomaticBackup.ts
+++ b/src/HIPAA-Security/rules/elasticache/hipaaSecurityElastiCacheRedisClusterAutomaticBackup.ts
@@ -4,6 +4,7 @@ SPDX-License-Identifier: Apache-2.0
 */
 import { CfnCacheCluster, CfnReplicationGroup } from '@aws-cdk/aws-elasticache';
 import { CfnResource } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * ElastiCache Redis clusters retain automatic backups for at least 15 days - (Control IDs: 164.308(a)(7)(i), 164.308(a)(7)(ii)(A), 164.308(a)(7)(ii)(B))
@@ -11,13 +12,13 @@ import { CfnResource } from '@aws-cdk/core';
  */
 export default function (node: CfnResource): boolean {
   if (node instanceof CfnCacheCluster) {
-    const engine = node.engine.toLowerCase();
-    const retention = node.snapshotRetentionLimit;
+    const engine = resolveIfPrimitive(node, node.engine.toLowerCase());
+    const retention = resolveIfPrimitive(node, node.snapshotRetentionLimit);
     if (engine == 'redis' && (retention == undefined || retention < 15)) {
       return false;
     }
   } else if (node instanceof CfnReplicationGroup) {
-    const retention = node.snapshotRetentionLimit;
+    const retention = resolveIfPrimitive(node, node.snapshotRetentionLimit);
     if (retention == undefined || retention < 15) {
       return false;
     }

--- a/src/HIPAA-Security/rules/elb/hipaaSecurityALBHttpDropInvalidHeaderEnabled.ts
+++ b/src/HIPAA-Security/rules/elb/hipaaSecurityALBHttpDropInvalidHeaderEnabled.ts
@@ -5,6 +5,7 @@ SPDX-License-Identifier: Apache-2.0
 
 import { CfnLoadBalancer } from '@aws-cdk/aws-elasticloadbalancingv2';
 import { CfnResource, Stack } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * Application Load Balancers are enabled to drop invalid headers - (Control IDs: 164.312(a)(2)(iv), 164.312(e)(1), 164.312(e)(2)(i), 164.312(e)(2)(ii))
@@ -12,7 +13,7 @@ import { CfnResource, Stack } from '@aws-cdk/core';
  */
 export default function (node: CfnResource): boolean {
   if (node instanceof CfnLoadBalancer) {
-    const type = Stack.of(node).resolve(node.type);
+    const type = resolveIfPrimitive(node, node.type);
     if (type == undefined || type == 'application') {
       const attributes = Stack.of(node).resolve(node.loadBalancerAttributes);
       if (attributes != undefined) {

--- a/src/HIPAA-Security/rules/elb/hipaaSecurityALBHttpToHttpsRedirection.ts
+++ b/src/HIPAA-Security/rules/elb/hipaaSecurityALBHttpToHttpsRedirection.ts
@@ -5,6 +5,7 @@ SPDX-License-Identifier: Apache-2.0
 
 import { CfnListener } from '@aws-cdk/aws-elasticloadbalancingv2';
 import { CfnResource, Stack } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * ALB HTTP listeners are configured to redirect to HTTPS - (Control IDs: 164.312(a)(2)(iv), 164.312(e)(1), 164.312(e)(2)(i), 164.312(e)(2)(ii))
@@ -13,7 +14,7 @@ import { CfnResource, Stack } from '@aws-cdk/core';
 export default function (node: CfnResource): boolean {
   if (node instanceof CfnListener) {
     let found = false;
-    const protocol = Stack.of(node).resolve(node.protocol);
+    const protocol = resolveIfPrimitive(node, node.protocol);
     const actions = Stack.of(node).resolve(node.defaultActions);
 
     if (protocol == 'HTTP') {

--- a/src/HIPAA-Security/rules/elb/hipaaSecurityELBACMCertificateRequired.ts
+++ b/src/HIPAA-Security/rules/elb/hipaaSecurityELBACMCertificateRequired.ts
@@ -5,6 +5,7 @@ SPDX-License-Identifier: Apache-2.0
 
 import { CfnLoadBalancer } from '@aws-cdk/aws-elasticloadbalancing';
 import { CfnResource, Stack } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * CLBs use ACM-managed certificates - (Control IDs: 164.312(a)(2)(iv), 164.312(e)(1), 164.312(e)(2)(i), 164.312(e)(2)(ii))
@@ -18,7 +19,10 @@ export default function (node: CfnResource): boolean {
       //Iterate through listeners, checking if secured ACM certs are used
       for (const listener of listeners) {
         const resolvedListener = Stack.of(node).resolve(listener);
-        const listenerARN = resolvedListener.sslCertificateId;
+        const listenerARN = resolveIfPrimitive(
+          node,
+          resolvedListener.sslCertificateId
+        );
         //Use the ARN to check if this is an ACM managed cert
         if (listenerARN == undefined) {
           return false;

--- a/src/HIPAA-Security/rules/elb/hipaaSecurityELBCrossZoneBalancingEnabled.ts
+++ b/src/HIPAA-Security/rules/elb/hipaaSecurityELBCrossZoneBalancingEnabled.ts
@@ -4,7 +4,8 @@ SPDX-License-Identifier: Apache-2.0
 */
 
 import { CfnLoadBalancer } from '@aws-cdk/aws-elasticloadbalancing';
-import { CfnResource, Stack } from '@aws-cdk/core';
+import { CfnResource } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * CLBs use at least two AZs with the Cross-Zone Load Balancing feature enabled - (Control IDs: 164.308(a)(7)(i), 164.308(a)(7)(ii)(C))
@@ -25,7 +26,7 @@ export default function (node: CfnResource): boolean {
     } else if (node.subnets.length < 2) {
       return false;
     }
-    const crossZone = Stack.of(node).resolve(node.crossZone);
+    const crossZone = resolveIfPrimitive(node, node.crossZone);
     if (crossZone != true) {
       return false;
     }

--- a/src/HIPAA-Security/rules/elb/hipaaSecurityELBLoggingEnabled.ts
+++ b/src/HIPAA-Security/rules/elb/hipaaSecurityELBLoggingEnabled.ts
@@ -5,6 +5,7 @@ SPDX-License-Identifier: Apache-2.0
 import { CfnLoadBalancer } from '@aws-cdk/aws-elasticloadbalancing';
 import { CfnLoadBalancer as CfnLoadBalancerV2 } from '@aws-cdk/aws-elasticloadbalancingv2';
 import { CfnResource, Stack } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * ELBs have access logs enabled - (Control ID: 164.312(b))
@@ -18,7 +19,7 @@ export default function (node: CfnResource): boolean {
     const accessLoggingPolicy = Stack.of(node).resolve(
       node.accessLoggingPolicy
     );
-    const enabled = Stack.of(node).resolve(accessLoggingPolicy.enabled);
+    const enabled = resolveIfPrimitive(node, accessLoggingPolicy.enabled);
 
     if (enabled == false) {
       return false;

--- a/src/HIPAA-Security/rules/elb/hipaaSecurityELBTlsHttpsListenersOnly.ts
+++ b/src/HIPAA-Security/rules/elb/hipaaSecurityELBTlsHttpsListenersOnly.ts
@@ -5,6 +5,7 @@ SPDX-License-Identifier: Apache-2.0
 
 import { CfnLoadBalancer } from '@aws-cdk/aws-elasticloadbalancing';
 import { CfnResource, Stack } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * CLB listeners are configured for secure (HTTPs or SSL) protocols for client communication - (Control IDs: 164.312(a)(2)(iv), 164.312(e)(1), 164.312(e)(2)(i), 164.312(e)(2)(ii))
@@ -15,20 +16,25 @@ export default function (node: CfnResource): boolean {
     const listeners = Stack.of(node).resolve(node.listeners);
     for (const listener of listeners) {
       const resolvedListener = Stack.of(node).resolve(listener);
-      if (resolvedListener.protocol.toLowerCase() == 'ssl') {
+      const protocol = resolveIfPrimitive(node, resolvedListener.protocol);
+      const instanceProtocol = resolveIfPrimitive(
+        node,
+        resolvedListener.instanceProtocol
+      );
+      if (protocol.toLowerCase() == 'ssl') {
         if (
           !(
-            resolvedListener.instanceProtocol == undefined ||
-            resolvedListener.instanceProtocol.toLowerCase() == 'ssl'
+            instanceProtocol == undefined ||
+            instanceProtocol.toLowerCase() == 'ssl'
           )
         ) {
           return false;
         }
-      } else if (resolvedListener.protocol.toLowerCase() == 'https') {
+      } else if (protocol.toLowerCase() == 'https') {
         if (
           !(
-            resolvedListener.instanceProtocol == undefined ||
-            resolvedListener.instanceProtocol.toLowerCase() == 'https'
+            instanceProtocol == undefined ||
+            instanceProtocol.toLowerCase() == 'https'
           )
         ) {
           return false;

--- a/src/HIPAA-Security/rules/lambda/hipaaSecurityLambdaConcurrency.ts
+++ b/src/HIPAA-Security/rules/lambda/hipaaSecurityLambdaConcurrency.ts
@@ -4,7 +4,8 @@ SPDX-License-Identifier: Apache-2.0
 */
 
 import { CfnFunction } from '@aws-cdk/aws-lambda';
-import { CfnResource, Stack } from '@aws-cdk/core';
+import { CfnResource } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * Lambda functions are configured with function-level concurrent execution limits - (Control ID: 164.312(b))
@@ -12,7 +13,8 @@ import { CfnResource, Stack } from '@aws-cdk/core';
  */
 export default function (node: CfnResource): boolean {
   if (node instanceof CfnFunction) {
-    const reservedConcurrentExecutions = Stack.of(node).resolve(
+    const reservedConcurrentExecutions = resolveIfPrimitive(
+      node,
       node.reservedConcurrentExecutions
     );
     if (

--- a/src/HIPAA-Security/rules/opensearch/hipaaSecurityOpenSearchEncryptedAtRest.ts
+++ b/src/HIPAA-Security/rules/opensearch/hipaaSecurityOpenSearchEncryptedAtRest.ts
@@ -5,6 +5,7 @@ SPDX-License-Identifier: Apache-2.0
 
 import { CfnDomain } from '@aws-cdk/aws-elasticsearch';
 import { CfnResource, Stack } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * OpenSearch Service domains have encryption at rest enabled - (Control IDs: 164.312(a)(2)(iv), 164.312(e)(2)(ii))
@@ -16,10 +17,8 @@ export default function (node: CfnResource): boolean {
       node.encryptionAtRestOptions
     );
     if (encryptionAtRestOptions != undefined) {
-      if (
-        encryptionAtRestOptions.enabled == undefined ||
-        encryptionAtRestOptions.enabled == false
-      ) {
+      const enabled = resolveIfPrimitive(node, encryptionAtRestOptions.enabled);
+      if (enabled !== true) {
         return false;
       }
     } else {

--- a/src/HIPAA-Security/rules/opensearch/hipaaSecurityOpenSearchNodeToNodeEncryption.ts
+++ b/src/HIPAA-Security/rules/opensearch/hipaaSecurityOpenSearchNodeToNodeEncryption.ts
@@ -5,6 +5,7 @@ SPDX-License-Identifier: Apache-2.0
 
 import { CfnDomain } from '@aws-cdk/aws-elasticsearch';
 import { CfnResource, Stack } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * OpenSearch Service domains are node-to-node encrypted - (Control IDs: 164.312(a)(2)(iv), 164.312(e)(1), 164.312(e)(2)(i), 164.312(e)(2)(ii))
@@ -16,10 +17,8 @@ export default function (node: CfnResource): boolean {
       node.nodeToNodeEncryptionOptions
     );
     if (encryptedNodeToNode != undefined) {
-      if (
-        encryptedNodeToNode.enabled == undefined ||
-        encryptedNodeToNode.enabled == false
-      ) {
+      const enabled = resolveIfPrimitive(node, encryptedNodeToNode.enabled);
+      if (enabled !== true) {
         return false;
       }
     } else {

--- a/src/HIPAA-Security/rules/rds/hipaaSecurityRDSAutomaticMinorVersionUpgradeEnabled.ts
+++ b/src/HIPAA-Security/rules/rds/hipaaSecurityRDSAutomaticMinorVersionUpgradeEnabled.ts
@@ -4,6 +4,7 @@ SPDX-License-Identifier: Apache-2.0
 */
 import { CfnDBInstance } from '@aws-cdk/aws-rds';
 import { CfnResource } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * RDS DB instances have automatic minor version upgrades enabled - (Control ID: 164.308(a)(5)(ii)(A))
@@ -11,7 +12,10 @@ import { CfnResource } from '@aws-cdk/core';
  */
 export default function (node: CfnResource): boolean {
   if (node instanceof CfnDBInstance) {
-    const autoMinorVersionUpgrade = node.autoMinorVersionUpgrade;
+    const autoMinorVersionUpgrade = resolveIfPrimitive(
+      node,
+      node.autoMinorVersionUpgrade
+    );
     if (autoMinorVersionUpgrade === false) {
       return false;
     }

--- a/src/HIPAA-Security/rules/rds/hipaaSecurityRDSEnhancedMonitoringEnabled.ts
+++ b/src/HIPAA-Security/rules/rds/hipaaSecurityRDSEnhancedMonitoringEnabled.ts
@@ -4,6 +4,7 @@ SPDX-License-Identifier: Apache-2.0
 */
 import { CfnDBInstance } from '@aws-cdk/aws-rds';
 import { CfnResource } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * RDS DB instances have enhanced monitoring enabled - (Control ID: 164.312(b))
@@ -11,7 +12,10 @@ import { CfnResource } from '@aws-cdk/core';
  */
 export default function (node: CfnResource): boolean {
   if (node instanceof CfnDBInstance) {
-    const enhancedMonitoring = node.monitoringInterval;
+    const enhancedMonitoring = resolveIfPrimitive(
+      node,
+      node.monitoringInterval
+    );
     if (enhancedMonitoring == undefined || enhancedMonitoring <= 0) {
       return false;
     }

--- a/src/HIPAA-Security/rules/rds/hipaaSecurityRDSInstanceBackupEnabled.ts
+++ b/src/HIPAA-Security/rules/rds/hipaaSecurityRDSInstanceBackupEnabled.ts
@@ -4,6 +4,7 @@ SPDX-License-Identifier: Apache-2.0
 */
 import { CfnDBInstance } from '@aws-cdk/aws-rds';
 import { CfnResource } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * RDS DB instances have backup enabled - (Control IDs: 164.308(a)(7)(i), 164.308(a)(7)(ii)(A), 164.308(a)(7)(ii)(B))
@@ -11,7 +12,7 @@ import { CfnResource } from '@aws-cdk/core';
  */
 export default function (node: CfnResource): boolean {
   if (node instanceof CfnDBInstance) {
-    const backup = node.backupRetentionPeriod;
+    const backup = resolveIfPrimitive(node, node.backupRetentionPeriod);
     if (backup == undefined || backup <= 0) {
       return false;
     }

--- a/src/HIPAA-Security/rules/rds/hipaaSecurityRDSInstanceDeletionProtectionEnabled.ts
+++ b/src/HIPAA-Security/rules/rds/hipaaSecurityRDSInstanceDeletionProtectionEnabled.ts
@@ -3,7 +3,8 @@ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 import { CfnDBCluster, CfnDBInstance } from '@aws-cdk/aws-rds';
-import { CfnResource, Stack } from '@aws-cdk/core';
+import { CfnResource } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  *  RDS DB instances and Aurora DB clusters have Deletion Protection enabled - (Control IDs: 164.308(a)(7)(i), 164.308(a)(7)(ii)(C))
@@ -14,17 +15,23 @@ export default function (node: CfnResource): boolean {
     if (node.deletionProtection == undefined) {
       return false;
     }
-    const deletionProtection = Stack.of(node).resolve(node.deletionProtection);
-    if (deletionProtection === false) {
+    const deletionProtection = resolveIfPrimitive(
+      node,
+      node.deletionProtection
+    );
+    if (deletionProtection == false) {
       return false;
     }
     return true;
   } else if (node instanceof CfnDBInstance) {
-    const deletionProtection = Stack.of(node).resolve(node.deletionProtection);
+    const deletionProtection = resolveIfPrimitive(
+      node,
+      node.deletionProtection
+    );
+    const engine = resolveIfPrimitive(node, node.engine);
     if (
       (deletionProtection == false || deletionProtection == undefined) &&
-      (node.engine == undefined ||
-        !node.engine.toLowerCase().includes('aurora'))
+      (engine == undefined || !engine.toLowerCase().includes('aurora'))
     ) {
       return false;
     }

--- a/src/HIPAA-Security/rules/rds/hipaaSecurityRDSInstanceMultiAZSupport.ts
+++ b/src/HIPAA-Security/rules/rds/hipaaSecurityRDSInstanceMultiAZSupport.ts
@@ -3,7 +3,8 @@ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 import { CfnDBInstance } from '@aws-cdk/aws-rds';
-import { CfnResource, Stack } from '@aws-cdk/core';
+import { CfnResource } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  *  Non-Aurora RDS DB instances have multi-AZ support enabled - (Control IDs: 164.308(a)(7)(i), 164.308(a)(7)(ii)(C))
@@ -11,11 +12,11 @@ import { CfnResource, Stack } from '@aws-cdk/core';
  */
 export default function (node: CfnResource): boolean {
   if (node instanceof CfnDBInstance) {
-    const multiAz = Stack.of(node).resolve(node.multiAz);
+    const multiAz = resolveIfPrimitive(node, node.multiAz);
+    const engine = resolveIfPrimitive(node, node.engine);
     if (
       !multiAz &&
-      (node.engine == undefined ||
-        !node.engine.toLowerCase().includes('aurora'))
+      (engine == undefined || !engine.toLowerCase().includes('aurora'))
     ) {
       return false;
     }

--- a/src/HIPAA-Security/rules/rds/hipaaSecurityRDSInstancePublicAccess.ts
+++ b/src/HIPAA-Security/rules/rds/hipaaSecurityRDSInstancePublicAccess.ts
@@ -3,7 +3,8 @@ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 import { CfnDBInstance } from '@aws-cdk/aws-rds';
-import { CfnResource, Stack } from '@aws-cdk/core';
+import { CfnResource } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * RDS DB instances are not publicly accessible - (Control IDs: 164.308(a)(3)(i), 164.308(a)(4)(ii)(A), 164.308(a)(4)(ii)(C), 164.312(a)(1), 164.312(e)(1))
@@ -11,8 +12,8 @@ import { CfnResource, Stack } from '@aws-cdk/core';
  */
 export default function (node: CfnResource): boolean {
   if (node instanceof CfnDBInstance) {
-    const publicAccess = Stack.of(node).resolve(node.publiclyAccessible);
-    if (publicAccess === true || publicAccess == undefined) {
+    const publicAccess = resolveIfPrimitive(node, node.publiclyAccessible);
+    if (publicAccess !== false) {
       return false;
     }
     return true;

--- a/src/HIPAA-Security/rules/rds/hipaaSecurityRDSLoggingEnabled.ts
+++ b/src/HIPAA-Security/rules/rds/hipaaSecurityRDSLoggingEnabled.ts
@@ -4,6 +4,7 @@ SPDX-License-Identifier: Apache-2.0
 */
 import { CfnDBInstance } from '@aws-cdk/aws-rds';
 import { CfnResource, Stack } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * RDS DB instances are configured to export all possible log types to CloudWatch - (Control IDs: 164.308(a)(3)(ii)(A), 164.308(a)(5)(ii)(C))
@@ -11,7 +12,7 @@ import { CfnResource, Stack } from '@aws-cdk/core';
  */
 export default function (node: CfnResource): boolean {
   if (node instanceof CfnDBInstance) {
-    const dbType = JSON.stringify(Stack.of(node).resolve(node.engine));
+    const dbType = JSON.stringify(resolveIfPrimitive(node, node.engine));
     const dbLogs = JSON.stringify(
       Stack.of(node).resolve(node.enableCloudwatchLogsExports)
     );

--- a/src/HIPAA-Security/rules/rds/hipaaSecurityRDSStorageEncrypted.ts
+++ b/src/HIPAA-Security/rules/rds/hipaaSecurityRDSStorageEncrypted.ts
@@ -3,7 +3,8 @@ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 import { CfnDBCluster, CfnDBInstance } from '@aws-cdk/aws-rds';
-import { CfnResource, Stack } from '@aws-cdk/core';
+import { CfnResource } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * RDS DB instances and Aurora DB clusters have storage encryption enabled - (Control IDs: 164.312(a)(2)(iv), 164.312(e)(2)(ii))
@@ -14,13 +15,12 @@ export default function (node: CfnResource): boolean {
     if (node.storageEncrypted == undefined) {
       return false;
     }
-    const encrypted = Stack.of(node).resolve(node.storageEncrypted);
+    const encrypted = resolveIfPrimitive(node, node.storageEncrypted);
     if (encrypted == false) {
       return false;
     }
-    return true;
   } else if (node instanceof CfnDBInstance) {
-    const encrypted = Stack.of(node).resolve(node.storageEncrypted);
+    const encrypted = resolveIfPrimitive(node, node.storageEncrypted);
     if (
       (encrypted == false || encrypted == undefined) &&
       (node.engine == undefined ||
@@ -28,7 +28,6 @@ export default function (node: CfnResource): boolean {
     ) {
       return false;
     }
-    return true;
   }
   return true;
 }

--- a/src/HIPAA-Security/rules/redshift/hipaaSecurityRedshiftBackupEnabled.ts
+++ b/src/HIPAA-Security/rules/redshift/hipaaSecurityRedshiftBackupEnabled.ts
@@ -4,6 +4,7 @@ SPDX-License-Identifier: Apache-2.0
 */
 import { CfnCluster } from '@aws-cdk/aws-redshift';
 import { CfnResource } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * Redshift clusters have automated snapshots enabled and the retention period is between 1 and 35 days - (Control IDs: 164.308(a)(7)(i), 164.308(a)(7)(ii)(A), 164.308(a)(7)(ii)(B))
@@ -11,9 +12,13 @@ import { CfnResource } from '@aws-cdk/core';
  */
 export default function (node: CfnResource): boolean {
   if (node instanceof CfnCluster) {
+    const automatedSnapshotRetentionPeriod = resolveIfPrimitive(
+      node,
+      node.automatedSnapshotRetentionPeriod
+    );
     if (
-      node.automatedSnapshotRetentionPeriod != undefined &&
-      node.automatedSnapshotRetentionPeriod == 0
+      automatedSnapshotRetentionPeriod != undefined &&
+      automatedSnapshotRetentionPeriod == 0
     ) {
       return false;
     }

--- a/src/HIPAA-Security/rules/redshift/hipaaSecurityRedshiftClusterConfiguration.ts
+++ b/src/HIPAA-Security/rules/redshift/hipaaSecurityRedshiftClusterConfiguration.ts
@@ -4,6 +4,7 @@ SPDX-License-Identifier: Apache-2.0
 */
 import { CfnCluster } from '@aws-cdk/aws-redshift';
 import { CfnResource, Stack } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * Redshift clusters have encryption and audit logging enabled - (Control IDs: 164.312(a)(2)(iv), 164.312(b), 164.312(e)(2)(ii))
@@ -11,7 +12,7 @@ import { CfnResource, Stack } from '@aws-cdk/core';
  */
 export default function (node: CfnResource): boolean {
   if (node instanceof CfnCluster) {
-    const encrypted = Stack.of(node).resolve(node.encrypted);
+    const encrypted = resolveIfPrimitive(node, node.encrypted);
     const loggingProperties = Stack.of(node).resolve(node.loggingProperties);
     if (!encrypted || loggingProperties == undefined) {
       return false;

--- a/src/HIPAA-Security/rules/redshift/hipaaSecurityRedshiftClusterMaintenanceSettings.ts
+++ b/src/HIPAA-Security/rules/redshift/hipaaSecurityRedshiftClusterMaintenanceSettings.ts
@@ -3,7 +3,8 @@ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 import { CfnCluster } from '@aws-cdk/aws-redshift';
-import { CfnResource, Stack } from '@aws-cdk/core';
+import { CfnResource } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * Redshift clusters have version upgrades enabled, automated snapshot retention periods enabled, and explicit maintenance windows configured - (Control IDs: 164.308(a)(5)(ii)(A), 164.308(a)(7)(ii)(A))
@@ -11,12 +12,17 @@ import { CfnResource, Stack } from '@aws-cdk/core';
  */
 export default function (node: CfnResource): boolean {
   if (node instanceof CfnCluster) {
-    const allowVersionUpgrade = Stack.of(node).resolve(
+    const allowVersionUpgrade = resolveIfPrimitive(
+      node,
       node.allowVersionUpgrade
     );
+    const automatedSnapshotRetentionPeriod = resolveIfPrimitive(
+      node,
+      node.automatedSnapshotRetentionPeriod
+    );
     if (
-      (node.automatedSnapshotRetentionPeriod != undefined &&
-        node.automatedSnapshotRetentionPeriod == 0) ||
+      (automatedSnapshotRetentionPeriod != undefined &&
+        automatedSnapshotRetentionPeriod == 0) ||
       node.preferredMaintenanceWindow == undefined ||
       allowVersionUpgrade === false
     ) {

--- a/src/HIPAA-Security/rules/redshift/hipaaSecurityRedshiftClusterPublicAccess.ts
+++ b/src/HIPAA-Security/rules/redshift/hipaaSecurityRedshiftClusterPublicAccess.ts
@@ -3,7 +3,8 @@ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 import { CfnCluster } from '@aws-cdk/aws-redshift';
-import { CfnResource, Stack } from '@aws-cdk/core';
+import { CfnResource } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * Redshift clusters do not allow public access - (Control IDs: 164.308(a)(3)(i), 164.308(a)(4)(ii)(A), 164.308(a)(4)(ii)(C), 164.312(a)(1), 164.312(e)(1))
@@ -11,8 +12,8 @@ import { CfnResource, Stack } from '@aws-cdk/core';
  */
 export default function (node: CfnResource): boolean {
   if (node instanceof CfnCluster) {
-    const publicAccess = Stack.of(node).resolve(node.publiclyAccessible);
-    if (publicAccess) {
+    const publicAccess = resolveIfPrimitive(node, node.publiclyAccessible);
+    if (publicAccess === true) {
       return false;
     }
   }

--- a/src/HIPAA-Security/rules/redshift/hipaaSecurityRedshiftEnhancedVPCRoutingEnabled.ts
+++ b/src/HIPAA-Security/rules/redshift/hipaaSecurityRedshiftEnhancedVPCRoutingEnabled.ts
@@ -3,7 +3,8 @@ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 import { CfnCluster } from '@aws-cdk/aws-redshift';
-import { CfnResource, Stack } from '@aws-cdk/core';
+import { CfnResource } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * Redshift clusters have enhanced VPC routing enabled - (Control IDs: 164.312(e)(1))
@@ -11,7 +12,10 @@ import { CfnResource, Stack } from '@aws-cdk/core';
  */
 export default function (node: CfnResource): boolean {
   if (node instanceof CfnCluster) {
-    const enhancedVpcRouting = Stack.of(node).resolve(node.enhancedVpcRouting);
+    const enhancedVpcRouting = resolveIfPrimitive(
+      node,
+      node.enhancedVpcRouting
+    );
     if (enhancedVpcRouting !== true) {
       return false;
     }

--- a/src/HIPAA-Security/rules/s3/hipaaSecurityS3BucketLevelPublicAccessProhibited.ts
+++ b/src/HIPAA-Security/rules/s3/hipaaSecurityS3BucketLevelPublicAccessProhibited.ts
@@ -4,6 +4,7 @@ SPDX-License-Identifier: Apache-2.0
 */
 import { CfnBucket } from '@aws-cdk/aws-s3';
 import { CfnResource, Stack } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * S3 Buckets prohibit public access through bucket level settings - (Control IDs: 164.308(a)(3)(i), 164.308(a)(4)(ii)(A), 164.308(a)(4)(ii)(C), 164.312(a)(1), 164.312(e)(1))
@@ -11,15 +12,33 @@ import { CfnResource, Stack } from '@aws-cdk/core';
  */
 export default function (node: CfnResource): boolean {
   if (node instanceof CfnBucket) {
-    const publicAccessBlockConfiguration = Stack.of(node).resolve(
+    if (node.publicAccessBlockConfiguration == undefined) {
+      return false;
+    }
+    const publicAccess = Stack.of(node).resolve(
       node.publicAccessBlockConfiguration
     );
+    const blockPublicAcls = resolveIfPrimitive(
+      node,
+      publicAccess.blockPublicAcls
+    );
+    const blockPublicPolicy = resolveIfPrimitive(
+      node,
+      publicAccess.blockPublicPolicy
+    );
+    const ignorePublicAcls = resolveIfPrimitive(
+      node,
+      publicAccess.ignorePublicAcls
+    );
+    const restrictPublicBuckets = resolveIfPrimitive(
+      node,
+      publicAccess.restrictPublicBuckets
+    );
     if (
-      publicAccessBlockConfiguration === undefined ||
-      publicAccessBlockConfiguration.blockPublicAcls !== true ||
-      publicAccessBlockConfiguration.blockPublicPolicy !== true ||
-      publicAccessBlockConfiguration.ignorePublicAcls !== true ||
-      publicAccessBlockConfiguration.restrictPublicBuckets !== true
+      blockPublicAcls !== true ||
+      blockPublicPolicy !== true ||
+      ignorePublicAcls !== true ||
+      restrictPublicBuckets !== true
     ) {
       return false;
     }

--- a/src/HIPAA-Security/rules/s3/hipaaSecurityS3BucketPublicReadProhibited.ts
+++ b/src/HIPAA-Security/rules/s3/hipaaSecurityS3BucketPublicReadProhibited.ts
@@ -4,6 +4,7 @@ SPDX-License-Identifier: Apache-2.0
 */
 import { CfnBucket } from '@aws-cdk/aws-s3';
 import { CfnResource, Stack } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * S3 Buckets prohibit public read access through their Block Public Access configurations and bucket ACLs - (Control IDs: 164.308(a)(3)(i), 164.308(a)(4)(ii)(A), 164.308(a)(4)(ii)(C), 164.312(a)(1), 164.312(e)(1))
@@ -16,14 +17,21 @@ export default function (node: CfnResource): boolean {
     );
     if (
       publicAccessBlockConfiguration === undefined ||
-      publicAccessBlockConfiguration.blockPublicPolicy !== true
+      resolveIfPrimitive(
+        node,
+        publicAccessBlockConfiguration.blockPublicPolicy
+      ) !== true
     ) {
       return false;
     }
-    const accessControl = Stack.of(node).resolve(node.accessControl);
+    const accessControl = resolveIfPrimitive(node, node.accessControl);
+    const blockPublicAcls = resolveIfPrimitive(
+      node,
+      publicAccessBlockConfiguration.blockPublicAcls
+    );
     if (
       (accessControl === 'PublicRead' || accessControl === 'PublicReadWrite') &&
-      publicAccessBlockConfiguration.blockPublicAcls !== true
+      blockPublicAcls !== true
     ) {
       return false;
     }

--- a/src/HIPAA-Security/rules/s3/hipaaSecurityS3BucketPublicWriteProhibited.ts
+++ b/src/HIPAA-Security/rules/s3/hipaaSecurityS3BucketPublicWriteProhibited.ts
@@ -4,6 +4,7 @@ SPDX-License-Identifier: Apache-2.0
 */
 import { CfnBucket } from '@aws-cdk/aws-s3';
 import { CfnResource, Stack } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * S3 Buckets prohibit public write access through their Block Public Access configurations and bucket ACLs - (Control IDs: 164.308(a)(3)(i), 164.308(a)(4)(ii)(A), 164.308(a)(4)(ii)(C), 164.312(a)(1), 164.312(e)(1))
@@ -16,15 +17,19 @@ export default function (node: CfnResource): boolean {
     );
     if (
       publicAccessBlockConfiguration === undefined ||
-      publicAccessBlockConfiguration.blockPublicPolicy !== true
+      resolveIfPrimitive(
+        node,
+        publicAccessBlockConfiguration.blockPublicPolicy
+      ) !== true
     ) {
       return false;
     }
-    const accessControl = Stack.of(node).resolve(node.accessControl);
-    if (
-      accessControl === 'PublicReadWrite' &&
-      publicAccessBlockConfiguration.blockPublicAcls !== true
-    ) {
+    const accessControl = resolveIfPrimitive(node, node.accessControl);
+    const blockPublicAcls = resolveIfPrimitive(
+      node,
+      publicAccessBlockConfiguration.blockPublicAcls
+    );
+    if (accessControl === 'PublicReadWrite' && blockPublicAcls !== true) {
       return false;
     }
   }

--- a/src/HIPAA-Security/rules/s3/hipaaSecurityS3BucketServerSideEncryptionEnabled.ts
+++ b/src/HIPAA-Security/rules/s3/hipaaSecurityS3BucketServerSideEncryptionEnabled.ts
@@ -4,6 +4,7 @@ SPDX-License-Identifier: Apache-2.0
 */
 import { CfnBucket } from '@aws-cdk/aws-s3';
 import { CfnResource, Stack } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * S3 Buckets have default server-side encryption enabled - (Control IDs: 164.312(a)(2)(iv), 164.312(c)(2), 164.312(e)(2)(ii))
@@ -15,11 +16,9 @@ export default function (node: CfnResource): boolean {
       return false;
     }
     const encryption = Stack.of(node).resolve(node.bucketEncryption);
-
     if (encryption.serverSideEncryptionConfiguration == undefined) {
       return false;
     }
-
     const sse = Stack.of(node).resolve(
       encryption.serverSideEncryptionConfiguration
     );
@@ -27,10 +26,16 @@ export default function (node: CfnResource): boolean {
       const defaultEncryption = Stack.of(node).resolve(
         rule.serverSideEncryptionByDefault
       );
+      if (defaultEncryption == undefined) {
+        return false;
+      }
+      const sseAlgorithm = resolveIfPrimitive(
+        node,
+        defaultEncryption.sseAlgorithm
+      );
       if (
-        defaultEncryption == undefined ||
-        (defaultEncryption.sseAlgorithm.toLowerCase() != 'aes256' &&
-          defaultEncryption.sseAlgorithm.toLowerCase() != 'aws:kms')
+        sseAlgorithm.toLowerCase() != 'aes256' &&
+        sseAlgorithm.toLowerCase() != 'aws:kms'
       ) {
         return false;
       }

--- a/src/HIPAA-Security/rules/s3/hipaaSecurityS3BucketVersioningEnabled.ts
+++ b/src/HIPAA-Security/rules/s3/hipaaSecurityS3BucketVersioningEnabled.ts
@@ -4,6 +4,7 @@ SPDX-License-Identifier: Apache-2.0
 */
 import { CfnBucket } from '@aws-cdk/aws-s3';
 import { CfnResource, Stack } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * S3 Buckets have versioningConfiguration enabled - (Control IDs: 164.308(a)(7)(i), 164.308(a)(7)(ii)(A), 164.308(a)(7)(ii)(B), 164.312(c)(1), 164.312(c)(2))
@@ -16,7 +17,7 @@ export default function (node: CfnResource): boolean {
     );
     if (
       versioningConfiguration === undefined ||
-      versioningConfiguration.status === 'Suspended'
+      resolveIfPrimitive(node, versioningConfiguration.status) === 'Suspended'
     ) {
       return false;
     }

--- a/src/HIPAA-Security/rules/s3/hipaaSecurityS3DefaultEncryptionKMS.ts
+++ b/src/HIPAA-Security/rules/s3/hipaaSecurityS3DefaultEncryptionKMS.ts
@@ -4,6 +4,7 @@ SPDX-License-Identifier: Apache-2.0
 */
 import { CfnBucket } from '@aws-cdk/aws-s3';
 import { CfnResource, Stack } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * S3 Buckets are encrypted with a KMS Key by default - (Control IDs: 164.312(a)(2)(iv), 164.312(e)(2)(ii))
@@ -15,11 +16,9 @@ export default function (node: CfnResource): boolean {
       return false;
     }
     const encryption = Stack.of(node).resolve(node.bucketEncryption);
-
     if (encryption.serverSideEncryptionConfiguration == undefined) {
       return false;
     }
-
     const sse = Stack.of(node).resolve(
       encryption.serverSideEncryptionConfiguration
     );
@@ -27,10 +26,14 @@ export default function (node: CfnResource): boolean {
       const defaultEncryption = Stack.of(node).resolve(
         rule.serverSideEncryptionByDefault
       );
-      if (
-        defaultEncryption == undefined ||
-        defaultEncryption.sseAlgorithm.toLowerCase() != 'aws:kms'
-      ) {
+      if (defaultEncryption == undefined) {
+        return false;
+      }
+      const sseAlgorithm = resolveIfPrimitive(
+        node,
+        defaultEncryption.sseAlgorithm
+      );
+      if (sseAlgorithm.toLowerCase() != 'aws:kms') {
         return false;
       }
     }

--- a/src/HIPAA-Security/rules/sagemaker/hipaaSecuritySageMakerNotebookNoDirectInternetAccess.ts
+++ b/src/HIPAA-Security/rules/sagemaker/hipaaSecuritySageMakerNotebookNoDirectInternetAccess.ts
@@ -4,7 +4,8 @@ SPDX-License-Identifier: Apache-2.0
 */
 
 import { CfnNotebookInstance } from '@aws-cdk/aws-sagemaker';
-import { CfnResource, Stack } from '@aws-cdk/core';
+import { CfnResource } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * SageMaker notebook instances have direct internet access disabled - (Control IDs: 164.308(a)(3)(i), 164.308(a)(4)(ii)(A), 164.308(a)(4)(ii)(C), 164.312(a)(1), 164.312(e)(1))
@@ -12,7 +13,8 @@ import { CfnResource, Stack } from '@aws-cdk/core';
  */
 export default function (node: CfnResource): boolean {
   if (node instanceof CfnNotebookInstance) {
-    const directInternetAccess = Stack.of(node).resolve(
+    const directInternetAccess = resolveIfPrimitive(
+      node,
       node.directInternetAccess
     );
     if (

--- a/src/HIPAA-Security/rules/secretsmanager/hipaaSecuritySecretsManagerUsingKMSKey.ts
+++ b/src/HIPAA-Security/rules/secretsmanager/hipaaSecuritySecretsManagerUsingKMSKey.ts
@@ -5,6 +5,7 @@ SPDX-License-Identifier: Apache-2.0
 
 import { CfnSecret } from '@aws-cdk/aws-secretsmanager';
 import { CfnResource } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * Secrets are encrypted with KMS Customer managed keys - (Control IDs: 164.312(a)(2)(iv), 164.312(e)(2)(ii))
@@ -12,7 +13,8 @@ import { CfnResource } from '@aws-cdk/core';
  */
 export default function (node: CfnResource): boolean {
   if (node instanceof CfnSecret) {
-    if (node.kmsKeyId === undefined || node.kmsKeyId === 'aws/secretsmanager') {
+    const kmsKeyId = resolveIfPrimitive(node, node.kmsKeyId);
+    if (kmsKeyId === undefined || kmsKeyId === 'aws/secretsmanager') {
       return false;
     }
   }

--- a/src/HIPAA-Security/rules/vpc/hipaaSecurityVPCNoUnrestrictedRouteToIGW.ts
+++ b/src/HIPAA-Security/rules/vpc/hipaaSecurityVPCNoUnrestrictedRouteToIGW.ts
@@ -5,6 +5,7 @@ SPDX-License-Identifier: Apache-2.0
 
 import { CfnRoute } from '@aws-cdk/aws-ec2';
 import { CfnResource } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * Route tables do not have unrestricted routes ('0.0.0.0/0' or '::/0') to IGWs - (Control ID: 164.312(e)(1))
@@ -13,15 +14,23 @@ import { CfnResource } from '@aws-cdk/core';
 export default function (node: CfnResource): boolean {
   if (node instanceof CfnRoute) {
     if (node.gatewayId != undefined) {
+      const destinationCidrBlock = resolveIfPrimitive(
+        node,
+        node.destinationCidrBlock
+      );
+      const destinationIpv6CidrBlock = resolveIfPrimitive(
+        node,
+        node.destinationIpv6CidrBlock
+      );
       if (
-        node.destinationCidrBlock != undefined &&
-        node.destinationCidrBlock.includes('/0')
+        destinationCidrBlock != undefined &&
+        destinationCidrBlock.includes('/0')
       ) {
         return false;
       }
       if (
-        node.destinationIpv6CidrBlock != undefined &&
-        node.destinationIpv6CidrBlock.includes('/0')
+        destinationIpv6CidrBlock != undefined &&
+        destinationIpv6CidrBlock.includes('/0')
       ) {
         return false;
       }

--- a/src/HIPAA-Security/rules/vpc/hipaaSecurityVPCSubnetAutoAssignPublicIpDisabled.ts
+++ b/src/HIPAA-Security/rules/vpc/hipaaSecurityVPCSubnetAutoAssignPublicIpDisabled.ts
@@ -4,7 +4,8 @@ SPDX-License-Identifier: Apache-2.0
 */
 
 import { CfnSubnet } from '@aws-cdk/aws-ec2';
-import { CfnResource, Stack } from '@aws-cdk/core';
+import { CfnResource } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * Subnets do not auto-assign public IP addresses - (Control IDs: 164.308(a)(3)(i), 164.308(a)(4)(ii)(A), 164.308(a)(4)(ii)(C), 164.312(a)(1), 164.312(e)(1))
@@ -12,10 +13,12 @@ import { CfnResource, Stack } from '@aws-cdk/core';
  */
 export default function (node: CfnResource): boolean {
   if (node instanceof CfnSubnet) {
-    const mapPublicIpOnLaunch = Stack.of(node).resolve(
+    const mapPublicIpOnLaunch = resolveIfPrimitive(
+      node,
       node.mapPublicIpOnLaunch
     );
-    const assignIpv6AddressOnCreation = Stack.of(node).resolve(
+    const assignIpv6AddressOnCreation = resolveIfPrimitive(
+      node,
       node.assignIpv6AddressOnCreation
     );
     if (mapPublicIpOnLaunch === true || assignIpv6AddressOnCreation === true) {

--- a/src/NIST-800-53/rules/autoscaling/nist80053AutoScalingHealthChecks.ts
+++ b/src/NIST-800-53/rules/autoscaling/nist80053AutoScalingHealthChecks.ts
@@ -5,7 +5,7 @@ SPDX-License-Identifier: Apache-2.0
 
 import { CfnAutoScalingGroup } from '@aws-cdk/aws-autoscaling';
 import { CfnResource, Stack } from '@aws-cdk/core';
-
+import { resolveIfPrimitive } from '../../../common';
 /**
  * Auto Scaling groups which are associated with load balancers utilize ELB health checks - (Control IDs: SC-5)
  * @param node the CfnResource to check
@@ -20,7 +20,7 @@ export default function (node: CfnResource): boolean {
       (otherLBs != undefined && otherLBs.length > 0) ||
       (classicLBs != undefined && classicLBs.length > 0)
     ) {
-      const healthCheckType = Stack.of(node).resolve(node.healthCheckType);
+      const healthCheckType = resolveIfPrimitive(node, node.healthCheckType);
       //Do we use ELB health checks?
       if (healthCheckType != undefined) {
         if (healthCheckType != 'ELB') {

--- a/src/NIST-800-53/rules/cloudtrail/nist80053CloudTrailLogFileValidationEnabled.ts
+++ b/src/NIST-800-53/rules/cloudtrail/nist80053CloudTrailLogFileValidationEnabled.ts
@@ -3,15 +3,15 @@ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 import { CfnTrail } from '@aws-cdk/aws-cloudtrail';
-import { CfnResource, Stack } from '@aws-cdk/core';
-
+import { CfnResource } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 /**
  * CloudTrail trails have log file validation enabled - (Control ID: AC-6)
  * @param node the CfnResource to check
  */
 export default function (node: CfnResource): boolean {
   if (node instanceof CfnTrail) {
-    const enabled = Stack.of(node).resolve(node.enableLogFileValidation);
+    const enabled = resolveIfPrimitive(node, node.enableLogFileValidation);
 
     if (enabled != true) {
       return false;

--- a/src/NIST-800-53/rules/codebuild/nist80053CodeBuildCheckEnvVars.ts
+++ b/src/NIST-800-53/rules/codebuild/nist80053CodeBuildCheckEnvVars.ts
@@ -5,6 +5,7 @@ SPDX-License-Identifier: Apache-2.0
 
 import { CfnProject } from '@aws-cdk/aws-codebuild';
 import { CfnResource, Stack } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * CodeBuild projects DO NOT store AWS credentials as plaintext environment variables - (Control IDs: AC-6, IA-5(7), SA-3(a))
@@ -21,15 +22,11 @@ export default function (node: CfnResource): boolean {
       //For each envvar, check if its a sensitive credential being stored
       for (const envVar of environmentVars) {
         const resolvedEnvVar = Stack.of(node).resolve(envVar);
-        if (
-          resolvedEnvVar.name == 'AWS_ACCESS_KEY_ID' ||
-          resolvedEnvVar.name == 'AWS_SECRET_ACCESS_KEY'
-        ) {
+        const name = resolveIfPrimitive(node, resolvedEnvVar.name);
+        const type = resolveIfPrimitive(node, resolvedEnvVar.type);
+        if (name == 'AWS_ACCESS_KEY_ID' || name == 'AWS_SECRET_ACCESS_KEY') {
           //is this credential being stored as plaintext?
-          if (
-            resolvedEnvVar.type == undefined ||
-            resolvedEnvVar.type == 'PLAINTEXT'
-          ) {
+          if (type == undefined || type == 'PLAINTEXT') {
             return false;
           }
         }

--- a/src/NIST-800-53/rules/codebuild/nist80053CodeBuildURLCheck.ts
+++ b/src/NIST-800-53/rules/codebuild/nist80053CodeBuildURLCheck.ts
@@ -5,6 +5,7 @@ SPDX-License-Identifier: Apache-2.0
 
 import { CfnProject } from '@aws-cdk/aws-codebuild';
 import { CfnResource, Stack } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * Codebuild projects with a GitHub or BitBucket source repository utilize OAUTH - (Control IDs: SA-3(a))
@@ -18,7 +19,7 @@ export default function (node: CfnResource): boolean {
     if (projectAuth == undefined) {
       return false;
     } else {
-      const projectAuthType = projectAuth.type;
+      const projectAuthType = resolveIfPrimitive(node, projectAuth.type);
       if (projectAuthType != 'OAUTH') {
         return false;
       }

--- a/src/NIST-800-53/rules/dms/nist80053DMSReplicationNotPublic.ts
+++ b/src/NIST-800-53/rules/dms/nist80053DMSReplicationNotPublic.ts
@@ -3,7 +3,8 @@ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 import { CfnReplicationInstance } from '@aws-cdk/aws-dms';
-import { CfnResource, Stack } from '@aws-cdk/core';
+import { CfnResource } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * DMS replication instances are not public - (Control ID: AC-4)
@@ -11,7 +12,7 @@ import { CfnResource, Stack } from '@aws-cdk/core';
  */
 export default function (node: CfnResource): boolean {
   if (node instanceof CfnReplicationInstance) {
-    const publicAccess = Stack.of(node).resolve(node.publiclyAccessible);
+    const publicAccess = resolveIfPrimitive(node, node.publiclyAccessible);
     if (publicAccess !== false) {
       return false;
     }

--- a/src/NIST-800-53/rules/dynamodb/nist80053DynamoDBPITREnabled.ts
+++ b/src/NIST-800-53/rules/dynamodb/nist80053DynamoDBPITREnabled.ts
@@ -4,6 +4,7 @@ SPDX-License-Identifier: Apache-2.0
 */
 import { CfnTable } from '@aws-cdk/aws-dynamodb';
 import { CfnResource, Stack } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * DynamoDB tables have Point-in-time Recovery enabled - (Control IDs: CP-9(b), CP-10, SI-12)
@@ -16,7 +17,7 @@ export default function (node: CfnResource): boolean {
       return false;
     }
     const pitr = Stack.of(node).resolve(node.pointInTimeRecoverySpecification);
-    const enabled = Stack.of(node).resolve(pitr.pointInTimeRecoveryEnabled);
+    const enabled = resolveIfPrimitive(node, pitr.pointInTimeRecoveryEnabled);
     if (!enabled) {
       return false;
     }

--- a/src/NIST-800-53/rules/ec2/nist80053EC2CheckCommonPortsRestricted.ts
+++ b/src/NIST-800-53/rules/ec2/nist80053EC2CheckCommonPortsRestricted.ts
@@ -5,6 +5,7 @@ SPDX-License-Identifier: Apache-2.0
 
 import { CfnSecurityGroupIngress, CfnSecurityGroup } from '@aws-cdk/aws-ec2';
 import { CfnResource, Stack } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 const BLOCKED_PORTS = [20, 21, 3389, 3309, 3306, 4333];
 
@@ -21,7 +22,7 @@ export default function (node: CfnResource): boolean {
       for (const rule of ingressRules) {
         const resolvedRule = Stack.of(node).resolve(rule);
         for (const portNum of BLOCKED_PORTS) {
-          if (!testPort(resolvedRule, portNum)) {
+          if (!testPort(node, resolvedRule, portNum)) {
             return false;
           }
         }
@@ -29,7 +30,7 @@ export default function (node: CfnResource): boolean {
     }
   } else if (node instanceof CfnSecurityGroupIngress) {
     for (const portNum of BLOCKED_PORTS) {
-      if (!testPort(node, portNum)) {
+      if (!testPort(node, node, portNum)) {
         return false;
       }
     }
@@ -39,32 +40,41 @@ export default function (node: CfnResource): boolean {
 
 /**
  * Helper function to identify if the given port number is unrestricted
+ * @param node the CfnResource to check
  * @param rule the CfnSecurityGroupIngress rule to check
  * @param portNum the number of the port to check
  */
-function testPort(rule: CfnSecurityGroupIngress, portNum: Number): boolean {
+function testPort(
+  node: CfnResource,
+  rule: CfnSecurityGroupIngress,
+  portNum: Number
+): boolean {
   //Does this rule apply to TCP traffic?
-  if (rule.ipProtocol != undefined && rule.ipProtocol == 'tcp') {
+  const ipProtocol = resolveIfPrimitive(node, rule.ipProtocol);
+  const cidrIp = resolveIfPrimitive(node, rule.cidrIp);
+  const fromPort = resolveIfPrimitive(node, rule.fromPort);
+  const toPort = resolveIfPrimitive(node, rule.toPort);
+  if (ipProtocol === 'tcp') {
     //Does this rule allow all IPv4 addresses (unrestricted access)?
-    if (rule.cidrIp != undefined && rule.cidrIp.includes('/0')) {
+    if (cidrIp != undefined && cidrIp.includes('/0')) {
       //Is a port range specified?
-      if (rule.fromPort != undefined && rule.toPort != undefined) {
+      if (fromPort != undefined && toPort != undefined) {
         if (
-          (rule.fromPort <= portNum && rule.toPort >= portNum) ||
-          rule.fromPort == -1 ||
-          rule.toPort == -1
+          (fromPort <= portNum && toPort >= portNum) ||
+          fromPort == -1 ||
+          toPort == -1
         ) {
           return false;
         }
       } else {
-        if (rule.fromPort == portNum) {
+        if (fromPort == portNum) {
           return false;
         }
       }
     }
   }
   //Are all ports allowed?
-  if (rule.ipProtocol != undefined && rule.ipProtocol == '-1') {
+  if (ipProtocol === '-1') {
     return false;
   }
   return true;

--- a/src/NIST-800-53/rules/ec2/nist80053EC2CheckDetailedMonitoring.ts
+++ b/src/NIST-800-53/rules/ec2/nist80053EC2CheckDetailedMonitoring.ts
@@ -5,7 +5,8 @@ SPDX-License-Identifier: Apache-2.0
 
 import { CfnLaunchConfiguration } from '@aws-cdk/aws-autoscaling';
 import { CfnInstance } from '@aws-cdk/aws-ec2';
-import { CfnResource, Stack } from '@aws-cdk/core';
+import { CfnResource } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * EC2 instances have detailed monitoring enabled - (Control IDs: CA-7(a)(b), SI-4(2), SI-4(a)(b)(c)).
@@ -13,12 +14,12 @@ import { CfnResource, Stack } from '@aws-cdk/core';
  */
 export default function (node: CfnResource): boolean {
   if (node instanceof CfnInstance) {
-    const monitoring = Stack.of(node).resolve(node.monitoring);
+    const monitoring = resolveIfPrimitive(node, node.monitoring);
     if (monitoring == undefined || monitoring == false) {
       return false;
     }
   } else if (node instanceof CfnLaunchConfiguration) {
-    const monitoring = Stack.of(node).resolve(node.instanceMonitoring);
+    const monitoring = resolveIfPrimitive(node, node.instanceMonitoring);
     if (monitoring != undefined && monitoring == false) {
       return false;
     }

--- a/src/NIST-800-53/rules/ec2/nist80053EC2CheckNoPublicIPs.ts
+++ b/src/NIST-800-53/rules/ec2/nist80053EC2CheckNoPublicIPs.ts
@@ -5,6 +5,7 @@ SPDX-License-Identifier: Apache-2.0
 
 import { CfnInstance } from '@aws-cdk/aws-ec2';
 import { CfnResource, Stack } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * EC2 instances do not have public IPs - (Control IDs: AC-4, AC-6, AC-21(b), SC-7, SC-7(3))
@@ -17,11 +18,11 @@ export default function (node: CfnResource): boolean {
       //Iterate through network interfaces, checking if public IPs are enabled
       for (const networkInterface of networkInterfaces) {
         const resolvedInterface = Stack.of(node).resolve(networkInterface);
-        if (resolvedInterface.associatePublicIpAddress != undefined) {
-          if (resolvedInterface.associatePublicIpAddress == true) {
-            return false;
-          }
-        } else {
+        const associatePublicIpAddress = resolveIfPrimitive(
+          node,
+          resolvedInterface.associatePublicIpAddress
+        );
+        if (associatePublicIpAddress === true) {
           return false;
         }
       }

--- a/src/NIST-800-53/rules/ec2/nist80053EC2CheckSSHRestricted.ts
+++ b/src/NIST-800-53/rules/ec2/nist80053EC2CheckSSHRestricted.ts
@@ -5,6 +5,7 @@ SPDX-License-Identifier: Apache-2.0
 
 import { CfnSecurityGroupIngress, CfnSecurityGroup } from '@aws-cdk/aws-ec2';
 import { CfnResource, Stack } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * Security Groups do not allow for unrestricted SSH traffic - (Control IDs: AC-4, SC-7, SC-7(3))
@@ -17,30 +18,26 @@ export default function (node: CfnResource): boolean {
       //For each ingress rule, ensure that it does not allow unrestricted SSH traffic.
       for (const rule of ingressRules) {
         const resolvedRule = Stack.of(node).resolve(rule);
+        const ipProtocol = resolveIfPrimitive(node, resolvedRule.ipProtocol);
+        const cidrIp = resolveIfPrimitive(node, resolvedRule.cidrIp);
+        const cidrIpv6 = resolveIfPrimitive(node, resolvedRule.cidrIpv6);
+        const fromPort = resolveIfPrimitive(node, resolvedRule.fromPort);
+        const toPort = resolveIfPrimitive(node, resolvedRule.toPort);
         if (
-          (resolvedRule.cidrIp != undefined &&
-            resolvedRule.cidrIp.includes('/0')) ||
-          (resolvedRule.cidrIpv6 != undefined &&
-            resolvedRule.cidrIpv6.includes('/0'))
+          (cidrIp != undefined && cidrIp.includes('/0')) ||
+          (cidrIpv6 != undefined && cidrIpv6.includes('/0'))
         ) {
-          //Is a port range specified?
-          if (
-            resolvedRule.fromPort != undefined &&
-            resolvedRule.toPort != undefined
-          ) {
+          if (fromPort != undefined && toPort != undefined) {
             if (
-              (resolvedRule.fromPort <= 22 && resolvedRule.toPort >= 22) ||
-              resolvedRule.fromPort == -1 ||
-              resolvedRule.toPort == -1 ||
-              resolvedRule.ipProtocol == '-1'
+              (fromPort <= 22 && toPort >= 22) ||
+              fromPort == -1 ||
+              toPort == -1 ||
+              ipProtocol == '-1'
             ) {
               return false;
             }
           } else {
-            if (
-              resolvedRule.fromPort == 22 ||
-              resolvedRule.ipProtocol == '-1'
-            ) {
+            if (fromPort == 22 || ipProtocol == '-1') {
               return false;
             }
           }
@@ -48,22 +45,27 @@ export default function (node: CfnResource): boolean {
       }
     }
   } else if (node instanceof CfnSecurityGroupIngress) {
+    const ipProtocol = resolveIfPrimitive(node, node.ipProtocol);
+    const cidrIp = resolveIfPrimitive(node, node.cidrIp);
+    const cidrIpv6 = resolveIfPrimitive(node, node.cidrIpv6);
+    const fromPort = resolveIfPrimitive(node, node.fromPort);
+    const toPort = resolveIfPrimitive(node, node.toPort);
     if (
-      (node.cidrIp != undefined && node.cidrIp.includes('/0')) ||
-      (node.cidrIpv6 != undefined && node.cidrIpv6.includes('/0'))
+      (cidrIp != undefined && cidrIp.includes('/0')) ||
+      (cidrIpv6 != undefined && cidrIpv6.includes('/0'))
     ) {
       //Is a port range specified?
-      if (node.fromPort != undefined && node.toPort != undefined) {
+      if (fromPort != undefined && toPort != undefined) {
         if (
-          (node.fromPort <= 22 && node.toPort >= 22) ||
-          node.fromPort == -1 ||
-          node.toPort == -1 ||
-          node.ipProtocol == '-1'
+          (fromPort <= 22 && toPort >= 22) ||
+          fromPort == -1 ||
+          toPort == -1 ||
+          ipProtocol == '-1'
         ) {
           return false;
         }
       } else {
-        if (node.fromPort == 22 || node.ipProtocol == '-1') {
+        if (fromPort == 22 || ipProtocol == '-1') {
           return false;
         }
       }

--- a/src/NIST-800-53/rules/efs/nist80053EFSEncrypted.ts
+++ b/src/NIST-800-53/rules/efs/nist80053EFSEncrypted.ts
@@ -3,7 +3,8 @@ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 import { CfnFileSystem } from '@aws-cdk/aws-efs';
-import { CfnResource, Stack } from '@aws-cdk/core';
+import { CfnResource } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * Elastic File Systems are configured for encryption at rest - (Control IDs: SC-13, SC-28)
@@ -11,11 +12,8 @@ import { CfnResource, Stack } from '@aws-cdk/core';
  */
 export default function (node: CfnResource): boolean {
   if (node instanceof CfnFileSystem) {
-    if (node.encrypted == undefined) {
-      return false;
-    }
-    const encrypted = Stack.of(node).resolve(node.encrypted);
-    if (encrypted == false) {
+    const encrypted = resolveIfPrimitive(node, node.encrypted);
+    if (encrypted === false) {
       return false;
     }
   }

--- a/src/NIST-800-53/rules/elasticache/nist80053ElastiCacheRedisClusterAutomaticBackup.ts
+++ b/src/NIST-800-53/rules/elasticache/nist80053ElastiCacheRedisClusterAutomaticBackup.ts
@@ -4,6 +4,7 @@ SPDX-License-Identifier: Apache-2.0
 */
 import { CfnCacheCluster, CfnReplicationGroup } from '@aws-cdk/aws-elasticache';
 import { CfnResource } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * ElastiCache Redis clusters retain automatic backups for at least 15 days - (Control IDs: CP-9(b), CP-10, SI-12)
@@ -11,13 +12,13 @@ import { CfnResource } from '@aws-cdk/core';
  */
 export default function (node: CfnResource): boolean {
   if (node instanceof CfnCacheCluster) {
-    const engine = node.engine.toLowerCase();
-    const retention = node.snapshotRetentionLimit;
+    const engine = resolveIfPrimitive(node, node.engine.toLowerCase());
+    const retention = resolveIfPrimitive(node, node.snapshotRetentionLimit);
     if (engine == 'redis' && (retention == undefined || retention < 15)) {
       return false;
     }
   } else if (node instanceof CfnReplicationGroup) {
-    const retention = node.snapshotRetentionLimit;
+    const retention = resolveIfPrimitive(node, node.snapshotRetentionLimit);
     if (retention == undefined || retention < 15) {
       return false;
     }

--- a/src/NIST-800-53/rules/elb/nist80053ALBHttpDropInvalidHeaderEnabled.ts
+++ b/src/NIST-800-53/rules/elb/nist80053ALBHttpDropInvalidHeaderEnabled.ts
@@ -5,6 +5,7 @@ SPDX-License-Identifier: Apache-2.0
 
 import { CfnLoadBalancer } from '@aws-cdk/aws-elasticloadbalancingv2';
 import { CfnResource, Stack } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * Application Load Balancers are enabled to drop invalid headers - (Control IDs: AC-17(2), SC-7, SC-8, SC-8(1), SC-23)
@@ -12,7 +13,7 @@ import { CfnResource, Stack } from '@aws-cdk/core';
  */
 export default function (node: CfnResource): boolean {
   if (node instanceof CfnLoadBalancer) {
-    const type = Stack.of(node).resolve(node.type);
+    const type = resolveIfPrimitive(node, node.type);
     if (type == undefined || type == 'application') {
       const attributes = Stack.of(node).resolve(node.loadBalancerAttributes);
       if (attributes != undefined) {

--- a/src/NIST-800-53/rules/elb/nist80053ALBHttpToHttpsRedirection.ts
+++ b/src/NIST-800-53/rules/elb/nist80053ALBHttpToHttpsRedirection.ts
@@ -5,6 +5,7 @@ SPDX-License-Identifier: Apache-2.0
 
 import { CfnListener } from '@aws-cdk/aws-elasticloadbalancingv2';
 import { CfnResource, Stack } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * ALB HTTP listeners are configured to redirect to HTTPS - (Control IDs: AC-17(2), SC-7, SC-8, SC-8(1), SC-13, SC-23)
@@ -13,7 +14,7 @@ import { CfnResource, Stack } from '@aws-cdk/core';
 export default function (node: CfnResource): boolean {
   if (node instanceof CfnListener) {
     let found = false;
-    const protocol = Stack.of(node).resolve(node.protocol);
+    const protocol = resolveIfPrimitive(node, node.protocol);
     const actions = Stack.of(node).resolve(node.defaultActions);
 
     if (protocol == 'HTTP') {

--- a/src/NIST-800-53/rules/elb/nist80053ELBCrossZoneBalancing.ts
+++ b/src/NIST-800-53/rules/elb/nist80053ELBCrossZoneBalancing.ts
@@ -4,7 +4,8 @@ SPDX-License-Identifier: Apache-2.0
 */
 
 import { CfnLoadBalancer } from '@aws-cdk/aws-elasticloadbalancing';
-import { CfnResource, Stack } from '@aws-cdk/core';
+import { CfnResource } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * CLBs use at least two AZs with the Cross-Zone Load Balancing feature enabled - (Control IDs: SC-5, CP-10)
@@ -25,7 +26,7 @@ export default function (node: CfnResource): boolean {
     } else if (node.subnets.length < 2) {
       return false;
     }
-    const crossZone = Stack.of(node).resolve(node.crossZone);
+    const crossZone = resolveIfPrimitive(node, node.crossZone);
     if (crossZone != true) {
       return false;
     }

--- a/src/NIST-800-53/rules/elb/nist80053ELBListenersUseSSLOrHTTPS.ts
+++ b/src/NIST-800-53/rules/elb/nist80053ELBListenersUseSSLOrHTTPS.ts
@@ -5,6 +5,7 @@ SPDX-License-Identifier: Apache-2.0
 
 import { CfnLoadBalancer } from '@aws-cdk/aws-elasticloadbalancing';
 import { CfnResource, Stack } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * CLB listeners are configured for secure (HTTPs or SSL) protocols for client communication - (Control IDs: AC-17(2), SC-7, SC-8, SC-8(1), SC-23)
@@ -15,20 +16,25 @@ export default function (node: CfnResource): boolean {
     const listeners = Stack.of(node).resolve(node.listeners);
     for (const listener of listeners) {
       const resolvedListener = Stack.of(node).resolve(listener);
-      if (resolvedListener.protocol.toLowerCase() == 'ssl') {
+      const protocol = resolveIfPrimitive(node, resolvedListener.protocol);
+      const instanceProtocol = resolveIfPrimitive(
+        node,
+        resolvedListener.instanceProtocol
+      );
+      if (protocol.toLowerCase() == 'ssl') {
         if (
           !(
-            resolvedListener.instanceProtocol == undefined ||
-            resolvedListener.instanceProtocol.toLowerCase() == 'ssl'
+            instanceProtocol == undefined ||
+            instanceProtocol.toLowerCase() == 'ssl'
           )
         ) {
           return false;
         }
-      } else if (resolvedListener.protocol.toLowerCase() == 'https') {
+      } else if (protocol.toLowerCase() == 'https') {
         if (
           !(
-            resolvedListener.instanceProtocol == undefined ||
-            resolvedListener.instanceProtocol.toLowerCase() == 'https'
+            instanceProtocol == undefined ||
+            instanceProtocol.toLowerCase() == 'https'
           )
         ) {
           return false;

--- a/src/NIST-800-53/rules/elb/nist80053ELBLoggingEnabled.ts
+++ b/src/NIST-800-53/rules/elb/nist80053ELBLoggingEnabled.ts
@@ -5,6 +5,7 @@ SPDX-License-Identifier: Apache-2.0
 import { CfnLoadBalancer } from '@aws-cdk/aws-elasticloadbalancing';
 import { CfnLoadBalancer as CfnLoadBalancerV2 } from '@aws-cdk/aws-elasticloadbalancingv2';
 import { CfnResource, Stack } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * ELBs have access logs enabled - (Control IDs: AU-2(a)(d), AU-3, AU-12(a)(c))
@@ -18,7 +19,7 @@ export default function (node: CfnResource): boolean {
     const accessLoggingPolicy = Stack.of(node).resolve(
       node.accessLoggingPolicy
     );
-    const enabled = Stack.of(node).resolve(accessLoggingPolicy.enabled);
+    const enabled = resolveIfPrimitive(node, accessLoggingPolicy.enabled);
 
     if (enabled == false) {
       return false;

--- a/src/NIST-800-53/rules/elb/nist80053ELBUseACMCerts.ts
+++ b/src/NIST-800-53/rules/elb/nist80053ELBUseACMCerts.ts
@@ -5,6 +5,7 @@ SPDX-License-Identifier: Apache-2.0
 
 import { CfnLoadBalancer } from '@aws-cdk/aws-elasticloadbalancing';
 import { CfnResource, Stack } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * CLBs utilize secure ACM-managed certificates - (Control IDs: AC-17(2), SC-7, SC-8, SC-8(1), SC-13)
@@ -18,7 +19,10 @@ export default function (node: CfnResource): boolean {
       //Iterate through listeners, checking if secured ACM certs are used
       for (const listener of listeners) {
         const resolvedListener = Stack.of(node).resolve(listener);
-        const listenerARN = resolvedListener.sslCertificateId;
+        const listenerARN = resolveIfPrimitive(
+          node,
+          resolvedListener.sslCertificateId
+        );
         //Use the ARN to check if this is an ACM managed cert
         if (listenerARN == undefined) {
           return false;

--- a/src/NIST-800-53/rules/opensearch/nist80053OpenSearchEncryptedAtRest.ts
+++ b/src/NIST-800-53/rules/opensearch/nist80053OpenSearchEncryptedAtRest.ts
@@ -5,6 +5,7 @@ SPDX-License-Identifier: Apache-2.0
 
 import { CfnDomain } from '@aws-cdk/aws-elasticsearch';
 import { CfnResource, Stack } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * OpenSearch Service domains have encryption at rest enabled - (Control IDs: SC-13, SC-28)
@@ -12,15 +13,12 @@ import { CfnResource, Stack } from '@aws-cdk/core';
  */
 export default function (node: CfnResource): boolean {
   if (node instanceof CfnDomain) {
-    //Is the encryption at rest property set?
     const encryptionAtRestOptions = Stack.of(node).resolve(
       node.encryptionAtRestOptions
     );
     if (encryptionAtRestOptions != undefined) {
-      if (
-        encryptionAtRestOptions.enabled == undefined ||
-        encryptionAtRestOptions.enabled == false
-      ) {
+      const enabled = resolveIfPrimitive(node, encryptionAtRestOptions.enabled);
+      if (enabled !== true) {
         return false;
       }
     } else {

--- a/src/NIST-800-53/rules/opensearch/nist80053OpenSearchNodeToNodeEncrypted.ts
+++ b/src/NIST-800-53/rules/opensearch/nist80053OpenSearchNodeToNodeEncrypted.ts
@@ -5,6 +5,7 @@ SPDX-License-Identifier: Apache-2.0
 
 import { CfnDomain } from '@aws-cdk/aws-elasticsearch';
 import { CfnResource, Stack } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * OpenSearch Service domains are node to node encrypted - (Control IDs: SC-7, SC-8, SC-8(1))
@@ -12,15 +13,12 @@ import { CfnResource, Stack } from '@aws-cdk/core';
  */
 export default function (node: CfnResource): boolean {
   if (node instanceof CfnDomain) {
-    //Is the node to node encryption property set?
     const encryptedNodeToNode = Stack.of(node).resolve(
       node.nodeToNodeEncryptionOptions
     );
     if (encryptedNodeToNode != undefined) {
-      if (
-        encryptedNodeToNode.enabled == undefined ||
-        encryptedNodeToNode.enabled == false
-      ) {
+      const enabled = resolveIfPrimitive(node, encryptedNodeToNode.enabled);
+      if (enabled !== true) {
         return false;
       }
     } else {

--- a/src/NIST-800-53/rules/rds/nist80053RDSEnhancedMonitoringEnabled.ts
+++ b/src/NIST-800-53/rules/rds/nist80053RDSEnhancedMonitoringEnabled.ts
@@ -4,6 +4,7 @@ SPDX-License-Identifier: Apache-2.0
 */
 import { CfnDBInstance } from '@aws-cdk/aws-rds';
 import { CfnResource } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * RDS DB instances have enhanced monitoring enabled - (Control ID: CA-7(a)(b))
@@ -11,7 +12,10 @@ import { CfnResource } from '@aws-cdk/core';
  */
 export default function (node: CfnResource): boolean {
   if (node instanceof CfnDBInstance) {
-    const enhancedMonitoring = node.monitoringInterval;
+    const enhancedMonitoring = resolveIfPrimitive(
+      node,
+      node.monitoringInterval
+    );
     if (enhancedMonitoring == undefined || enhancedMonitoring <= 0) {
       return false;
     }

--- a/src/NIST-800-53/rules/rds/nist80053RDSInstanceBackupEnabled.ts
+++ b/src/NIST-800-53/rules/rds/nist80053RDSInstanceBackupEnabled.ts
@@ -4,6 +4,7 @@ SPDX-License-Identifier: Apache-2.0
 */
 import { CfnDBInstance } from '@aws-cdk/aws-rds';
 import { CfnResource } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * RDS DB instances have backup enabled - (Control IDs: CP-9(b), CP-10, SI-12)
@@ -11,7 +12,7 @@ import { CfnResource } from '@aws-cdk/core';
  */
 export default function (node: CfnResource): boolean {
   if (node instanceof CfnDBInstance) {
-    const backup = node.backupRetentionPeriod;
+    const backup = resolveIfPrimitive(node, node.backupRetentionPeriod);
     if (backup == undefined || backup <= 0) {
       return false;
     }

--- a/src/NIST-800-53/rules/rds/nist80053RDSInstanceDeletionProtectionEnabled.ts
+++ b/src/NIST-800-53/rules/rds/nist80053RDSInstanceDeletionProtectionEnabled.ts
@@ -3,7 +3,8 @@ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 import { CfnDBCluster, CfnDBInstance } from '@aws-cdk/aws-rds';
-import { CfnResource, Stack } from '@aws-cdk/core';
+import { CfnResource } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  *  RDS DB instances and Aurora DB clusters have Deletion Protection enabled - (Control ID: SC-5)
@@ -14,17 +15,23 @@ export default function (node: CfnResource): boolean {
     if (node.deletionProtection == undefined) {
       return false;
     }
-    const deletionProtection = Stack.of(node).resolve(node.deletionProtection);
-    if (deletionProtection === false) {
+    const deletionProtection = resolveIfPrimitive(
+      node,
+      node.deletionProtection
+    );
+    if (deletionProtection == false) {
       return false;
     }
     return true;
   } else if (node instanceof CfnDBInstance) {
-    const deletionProtection = Stack.of(node).resolve(node.deletionProtection);
+    const deletionProtection = resolveIfPrimitive(
+      node,
+      node.deletionProtection
+    );
+    const engine = resolveIfPrimitive(node, node.engine);
     if (
       (deletionProtection == false || deletionProtection == undefined) &&
-      (node.engine == undefined ||
-        !node.engine.toLowerCase().includes('aurora'))
+      (engine == undefined || !engine.toLowerCase().includes('aurora'))
     ) {
       return false;
     }

--- a/src/NIST-800-53/rules/rds/nist80053RDSInstanceMultiAZSupport.ts
+++ b/src/NIST-800-53/rules/rds/nist80053RDSInstanceMultiAZSupport.ts
@@ -3,7 +3,8 @@ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 import { CfnDBInstance } from '@aws-cdk/aws-rds';
-import { CfnResource, Stack } from '@aws-cdk/core';
+import { CfnResource } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  *  Non-Aurora RDS DB instances have multi-AZ support enabled - (Control IDs: CP-10, SC-5, SC-36)
@@ -11,11 +12,11 @@ import { CfnResource, Stack } from '@aws-cdk/core';
  */
 export default function (node: CfnResource): boolean {
   if (node instanceof CfnDBInstance) {
-    const multiAz = Stack.of(node).resolve(node.multiAz);
+    const multiAz = resolveIfPrimitive(node, node.multiAz);
+    const engine = resolveIfPrimitive(node, node.engine);
     if (
       !multiAz &&
-      (node.engine == undefined ||
-        !node.engine.toLowerCase().includes('aurora'))
+      (engine == undefined || !engine.toLowerCase().includes('aurora'))
     ) {
       return false;
     }

--- a/src/NIST-800-53/rules/rds/nist80053RDSInstancePublicAccess.ts
+++ b/src/NIST-800-53/rules/rds/nist80053RDSInstancePublicAccess.ts
@@ -3,7 +3,8 @@ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 import { CfnDBInstance } from '@aws-cdk/aws-rds';
-import { CfnResource, Stack } from '@aws-cdk/core';
+import { CfnResource } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * RDS DB instances are not publicly accessible - (Control IDs: AC-4, AC-6, AC-21(b), SC-7, SC-7(3))
@@ -11,8 +12,8 @@ import { CfnResource, Stack } from '@aws-cdk/core';
  */
 export default function (node: CfnResource): boolean {
   if (node instanceof CfnDBInstance) {
-    const publicAccess = Stack.of(node).resolve(node.publiclyAccessible);
-    if (publicAccess === true || publicAccess == undefined) {
+    const publicAccess = resolveIfPrimitive(node, node.publiclyAccessible);
+    if (publicAccess !== false) {
       return false;
     }
     return true;

--- a/src/NIST-800-53/rules/rds/nist80053RDSLoggingEnabled.ts
+++ b/src/NIST-800-53/rules/rds/nist80053RDSLoggingEnabled.ts
@@ -4,6 +4,7 @@ SPDX-License-Identifier: Apache-2.0
 */
 import { CfnDBInstance } from '@aws-cdk/aws-rds';
 import { CfnResource, Stack } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * RDS DB instances are configured to export all possible log types to CloudWatch - (Control IDs: AC-2(4), AC-2(g), AU-2(a)(d), AU-3, AU-12(a)(c))
@@ -11,7 +12,7 @@ import { CfnResource, Stack } from '@aws-cdk/core';
  */
 export default function (node: CfnResource): boolean {
   if (node instanceof CfnDBInstance) {
-    const dbType = JSON.stringify(Stack.of(node).resolve(node.engine));
+    const dbType = JSON.stringify(resolveIfPrimitive(node, node.engine));
     const dbLogs = JSON.stringify(
       Stack.of(node).resolve(node.enableCloudwatchLogsExports)
     );

--- a/src/NIST-800-53/rules/rds/nist80053RDSStorageEncrypted.ts
+++ b/src/NIST-800-53/rules/rds/nist80053RDSStorageEncrypted.ts
@@ -3,7 +3,8 @@ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 import { CfnDBCluster, CfnDBInstance } from '@aws-cdk/aws-rds';
-import { CfnResource, Stack } from '@aws-cdk/core';
+import { CfnResource } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * RDS DB instances and Aurora DB clusters have storage encryption enabled - (Control IDs: SC-13, SC-28)
@@ -14,13 +15,12 @@ export default function (node: CfnResource): boolean {
     if (node.storageEncrypted == undefined) {
       return false;
     }
-    const encrypted = Stack.of(node).resolve(node.storageEncrypted);
+    const encrypted = resolveIfPrimitive(node, node.storageEncrypted);
     if (encrypted == false) {
       return false;
     }
-    return true;
   } else if (node instanceof CfnDBInstance) {
-    const encrypted = Stack.of(node).resolve(node.storageEncrypted);
+    const encrypted = resolveIfPrimitive(node, node.storageEncrypted);
     if (
       (encrypted == false || encrypted == undefined) &&
       (node.engine == undefined ||
@@ -28,7 +28,6 @@ export default function (node: CfnResource): boolean {
     ) {
       return false;
     }
-    return true;
   }
   return true;
 }

--- a/src/NIST-800-53/rules/redshift/nist80053RedshiftClusterConfiguration.ts
+++ b/src/NIST-800-53/rules/redshift/nist80053RedshiftClusterConfiguration.ts
@@ -4,6 +4,7 @@ SPDX-License-Identifier: Apache-2.0
 */
 import { CfnCluster } from '@aws-cdk/aws-redshift';
 import { CfnResource, Stack } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * Redshift clusters have encryption and audit logging enabled - (Control IDs: AC-2(4), AC-2(g), AU-2(a)(d), AU-3, AU-12(a)(c), SC-13)
@@ -11,7 +12,7 @@ import { CfnResource, Stack } from '@aws-cdk/core';
  */
 export default function (node: CfnResource): boolean {
   if (node instanceof CfnCluster) {
-    const encrypted = Stack.of(node).resolve(node.encrypted);
+    const encrypted = resolveIfPrimitive(node, node.encrypted);
     const loggingProperties = Stack.of(node).resolve(node.loggingProperties);
     if (!encrypted || loggingProperties == undefined) {
       return false;

--- a/src/NIST-800-53/rules/redshift/nist80053RedshiftClusterPublicAccess.ts
+++ b/src/NIST-800-53/rules/redshift/nist80053RedshiftClusterPublicAccess.ts
@@ -3,7 +3,8 @@ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 import { CfnCluster } from '@aws-cdk/aws-redshift';
-import { CfnResource, Stack } from '@aws-cdk/core';
+import { CfnResource } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * Redshift clusters do not allow public access - (Control IDs: AC-3, AC-4, AC-6, AC-21(b), SC-7, SC-7(3))
@@ -11,8 +12,8 @@ import { CfnResource, Stack } from '@aws-cdk/core';
  */
 export default function (node: CfnResource): boolean {
   if (node instanceof CfnCluster) {
-    const publicAccess = Stack.of(node).resolve(node.publiclyAccessible);
-    if (publicAccess) {
+    const publicAccess = resolveIfPrimitive(node, node.publiclyAccessible);
+    if (publicAccess === true) {
       return false;
     }
   }

--- a/src/NIST-800-53/rules/s3/nist80053S3BucketDefaultLockEnabled.ts
+++ b/src/NIST-800-53/rules/s3/nist80053S3BucketDefaultLockEnabled.ts
@@ -4,6 +4,7 @@ SPDX-License-Identifier: Apache-2.0
 */
 import { CfnBucket } from '@aws-cdk/aws-s3';
 import { CfnResource, Stack } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * S3 Buckets have object lock enabled - (Control ID: SC-28)
@@ -11,14 +12,15 @@ import { CfnResource, Stack } from '@aws-cdk/core';
  */
 export default function (node: CfnResource): boolean {
   if (node instanceof CfnBucket) {
-    const objectLockEnabled = Stack.of(node).resolve(node.objectLockEnabled);
+    const objectLockEnabled = resolveIfPrimitive(node, node.objectLockEnabled);
     const objectLockConfiguration = Stack.of(node).resolve(
       node.objectLockConfiguration
     );
     if (
       objectLockEnabled !== true ||
       objectLockConfiguration === undefined ||
-      objectLockConfiguration.objectLockEnabled !== 'Enabled'
+      resolveIfPrimitive(node, objectLockConfiguration.objectLockEnabled) !==
+        'Enabled'
     ) {
       return false;
     }

--- a/src/NIST-800-53/rules/s3/nist80053S3BucketPublicReadProhibited.ts
+++ b/src/NIST-800-53/rules/s3/nist80053S3BucketPublicReadProhibited.ts
@@ -4,6 +4,7 @@ SPDX-License-Identifier: Apache-2.0
 */
 import { CfnBucket } from '@aws-cdk/aws-s3';
 import { CfnResource, Stack } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * S3 Buckets prohibit public read access through their Block Public Access configurations and bucket ACLs - (Control IDs: AC-3, AC-4, AC-6, AC-21(b), SC-7, SC-7(3))
@@ -16,14 +17,21 @@ export default function (node: CfnResource): boolean {
     );
     if (
       publicAccessBlockConfiguration === undefined ||
-      publicAccessBlockConfiguration.blockPublicPolicy !== true
+      resolveIfPrimitive(
+        node,
+        publicAccessBlockConfiguration.blockPublicPolicy
+      ) !== true
     ) {
       return false;
     }
-    const accessControl = Stack.of(node).resolve(node.accessControl);
+    const accessControl = resolveIfPrimitive(node, node.accessControl);
+    const blockPublicAcls = resolveIfPrimitive(
+      node,
+      publicAccessBlockConfiguration.blockPublicAcls
+    );
     if (
       (accessControl === 'PublicRead' || accessControl === 'PublicReadWrite') &&
-      publicAccessBlockConfiguration.blockPublicAcls !== true
+      blockPublicAcls !== true
     ) {
       return false;
     }

--- a/src/NIST-800-53/rules/s3/nist80053S3BucketPublicWriteProhibited.ts
+++ b/src/NIST-800-53/rules/s3/nist80053S3BucketPublicWriteProhibited.ts
@@ -4,6 +4,7 @@ SPDX-License-Identifier: Apache-2.0
 */
 import { CfnBucket } from '@aws-cdk/aws-s3';
 import { CfnResource, Stack } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * S3 Buckets prohibit public write access through their Block Public Access configurations and bucket ACLs - (Control IDs: AC-3, AC-4, AC-6, AC-21(b), SC-7, SC-7(3))
@@ -16,15 +17,19 @@ export default function (node: CfnResource): boolean {
     );
     if (
       publicAccessBlockConfiguration === undefined ||
-      publicAccessBlockConfiguration.blockPublicPolicy !== true
+      resolveIfPrimitive(
+        node,
+        publicAccessBlockConfiguration.blockPublicPolicy
+      ) !== true
     ) {
       return false;
     }
-    const accessControl = Stack.of(node).resolve(node.accessControl);
-    if (
-      accessControl === 'PublicReadWrite' &&
-      publicAccessBlockConfiguration.blockPublicAcls !== true
-    ) {
+    const accessControl = resolveIfPrimitive(node, node.accessControl);
+    const blockPublicAcls = resolveIfPrimitive(
+      node,
+      publicAccessBlockConfiguration.blockPublicAcls
+    );
+    if (accessControl === 'PublicReadWrite' && blockPublicAcls !== true) {
       return false;
     }
   }

--- a/src/NIST-800-53/rules/s3/nist80053S3BucketServerSideEncryptionEnabled.ts
+++ b/src/NIST-800-53/rules/s3/nist80053S3BucketServerSideEncryptionEnabled.ts
@@ -4,6 +4,7 @@ SPDX-License-Identifier: Apache-2.0
 */
 import { CfnBucket } from '@aws-cdk/aws-s3';
 import { CfnResource, Stack } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * S3 Buckets have default server-side encryption enabled - (Control IDs: AU-9(2), CP-9(b), CP-10, SC-5, SC-36)
@@ -15,11 +16,9 @@ export default function (node: CfnResource): boolean {
       return false;
     }
     const encryption = Stack.of(node).resolve(node.bucketEncryption);
-
     if (encryption.serverSideEncryptionConfiguration == undefined) {
       return false;
     }
-
     const sse = Stack.of(node).resolve(
       encryption.serverSideEncryptionConfiguration
     );
@@ -27,10 +26,16 @@ export default function (node: CfnResource): boolean {
       const defaultEncryption = Stack.of(node).resolve(
         rule.serverSideEncryptionByDefault
       );
+      if (defaultEncryption == undefined) {
+        return false;
+      }
+      const sseAlgorithm = resolveIfPrimitive(
+        node,
+        defaultEncryption.sseAlgorithm
+      );
       if (
-        defaultEncryption == undefined ||
-        (defaultEncryption.sseAlgorithm.toLowerCase() != 'aes256' &&
-          defaultEncryption.sseAlgorithm.toLowerCase() != 'aws:kms')
+        sseAlgorithm.toLowerCase() != 'aes256' &&
+        sseAlgorithm.toLowerCase() != 'aws:kms'
       ) {
         return false;
       }

--- a/src/NIST-800-53/rules/s3/nist80053S3BucketVersioningEnabled.ts
+++ b/src/NIST-800-53/rules/s3/nist80053S3BucketVersioningEnabled.ts
@@ -4,6 +4,7 @@ SPDX-License-Identifier: Apache-2.0
 */
 import { CfnBucket } from '@aws-cdk/aws-s3';
 import { CfnResource, Stack } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * S3 Buckets have versioningConfiguration enabled - (Control IDs: CP-10, SI-12)
@@ -16,7 +17,7 @@ export default function (node: CfnResource): boolean {
     );
     if (
       versioningConfiguration === undefined ||
-      versioningConfiguration.status === 'Suspended'
+      resolveIfPrimitive(node, versioningConfiguration.status) === 'Suspended'
     ) {
       return false;
     }

--- a/src/NIST-800-53/rules/sagemaker/nist80053SageMakerNotebookDirectInternetAccessDisabled.ts
+++ b/src/NIST-800-53/rules/sagemaker/nist80053SageMakerNotebookDirectInternetAccessDisabled.ts
@@ -4,7 +4,8 @@ SPDX-License-Identifier: Apache-2.0
 */
 
 import { CfnNotebookInstance } from '@aws-cdk/aws-sagemaker';
-import { CfnResource, Stack } from '@aws-cdk/core';
+import { CfnResource } from '@aws-cdk/core';
+import { resolveIfPrimitive } from '../../../common';
 
 /**
  * SageMaker notebook instances have direct internet access disabled - (Control IDs: AC-3, AC-4, AC-6, AC-21(b), SC-7, SC-7(3))
@@ -12,7 +13,8 @@ import { CfnResource, Stack } from '@aws-cdk/core';
  */
 export default function (node: CfnResource): boolean {
   if (node instanceof CfnNotebookInstance) {
-    const directInternetAccess = Stack.of(node).resolve(
+    const directInternetAccess = resolveIfPrimitive(
+      node,
       node.directInternetAccess
     );
     if (

--- a/src/common.ts
+++ b/src/common.ts
@@ -2,7 +2,13 @@
 Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
-import { IAspect, IConstruct, Annotations, CfnResource } from '@aws-cdk/core';
+import {
+  IAspect,
+  IConstruct,
+  Annotations,
+  CfnResource,
+  Stack,
+} from '@aws-cdk/core';
 
 const VALIDATION_FAILURE_ID = 'CdkNagValidationFailure';
 
@@ -151,5 +157,25 @@ export abstract class NagPack implements IAspect {
   ): string {
     let message = `${ruleId}: ${info}`;
     return this.verbose ? `${message} ${explanation}` : message;
+  }
+}
+
+/**
+ * Return a value if resolves to a primitive data type, otherwise throw an error
+ * https://developer.mozilla.org/en-US/docs/Glossary/Primitive
+ * @param node the CfnResource to check
+ * @param parameter the value to attempt to resolve
+ * @returns any
+ */
+export function resolveIfPrimitive(node: CfnResource, parameter: any): any {
+  const resolvedValue = Stack.of(node).resolve(parameter);
+  if (resolvedValue === Object(resolvedValue)) {
+    throw Error(
+      `The parameter resolved to to a non-primitive value "${JSON.stringify(
+        resolvedValue
+      )}", therefore the rule could not be validated.`
+    );
+  } else {
+    return resolvedValue;
   }
 }

--- a/src/common.ts
+++ b/src/common.ts
@@ -161,11 +161,11 @@ export abstract class NagPack implements IAspect {
 }
 
 /**
- * Return a value if resolves to a primitive data type, otherwise throw an error
+ * Use in cases where a primitive value must be known to pass a rule
  * https://developer.mozilla.org/en-US/docs/Glossary/Primitive
  * @param node the CfnResource to check
  * @param parameter the value to attempt to resolve
- * @returns any
+ * @returns Return a value if resolves to a primitive data type, otherwise throw an error.
  */
 export function resolveIfPrimitive(node: CfnResource, parameter: any): any {
   const resolvedValue = Stack.of(node).resolve(parameter);

--- a/test/Engine.test.ts
+++ b/test/Engine.test.ts
@@ -224,6 +224,7 @@ describe('Testing rule exception handling', () => {
         { id: 'CdkNagValidationFailure', reason: 'at least 10 characters' },
       ],
     });
+    console.log(typeof { Ref: 'pDbPort' });
     const messages = SynthUtils.synthesize(stack).messages;
     expect(messages).not.toContainEqual(
       expect.objectContaining({


### PR DESCRIPTION
Resolves #393 

With this, the `resolveIfPrimitive` function has been added to allow rules to check if a value is an encoded token that resolves to a non primitive data type (like Intrinsic Functions). Rules that must know specific values of `string`, `boolean`, or `number` can use this to resolve values and throw validation warnings if an intrinsic function is detected.

Additionally all relevant rules in the `AwsSsolutions`, `NIST 800-53`, and `HIPAA Security` Packs have been updated to use this functionality 

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*