### PR TITLE
fix(AWS Solutions, HIPAA-Security, NIST 800-R3 rev5): false postive for Secrets Manager rotation rules when using Secret Target Attachments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,6 +30,7 @@ jspm_packages/
 *.tgz
 .yarn-integrity
 .cache
+.vscode
 !/.projenrc.js
 /test-reports/
 junit.xml

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -103,6 +103,7 @@ const project = new AwsCdkConstructLibrary({
   },
   buildWorkflow: true,
   release: true,
+  gitignore: ['.vscode'],
 });
 project.package.addField('resolutions', {
   'ansi-regex': '^5.0.1',

--- a/test/NIST-800-53-R5/NIST-800-53-R5-SecretsManager.test.ts
+++ b/test/NIST-800-53-R5/NIST-800-53-R5-SecretsManager.test.ts
@@ -5,7 +5,13 @@ SPDX-License-Identifier: Apache-2.0
 import { SynthUtils } from '@aws-cdk/assert';
 import { Key } from '@aws-cdk/aws-kms';
 import { Function } from '@aws-cdk/aws-lambda';
-import { Secret, CfnSecret, HostedRotation } from '@aws-cdk/aws-secretsmanager';
+import {
+  Secret,
+  CfnSecret,
+  HostedRotation,
+  CfnRotationSchedule,
+  CfnSecretTargetAttachment,
+} from '@aws-cdk/aws-secretsmanager';
 import { Aspects, Duration, Stack } from '@aws-cdk/core';
 import { NIST80053R5Checks } from '../../src';
 
@@ -24,6 +30,59 @@ describe('AWS Secrets Manager', () => {
         }),
       })
     );
+
+    const nonCompliant2 = new Stack();
+    Aspects.of(nonCompliant2).add(new NIST80053R5Checks());
+    new CfnRotationSchedule(nonCompliant2, 'rRotationSchedule', {
+      secretId: new CfnSecretTargetAttachment(
+        nonCompliant2,
+        'rCfnTargetAttachment',
+        {
+          secretId: new Secret(nonCompliant2, 'rSecret').secretArn,
+          targetId: 'foo',
+          targetType: 'bar',
+        }
+      ).ref,
+      hostedRotationLambda: { rotationType: 'baz' },
+    });
+    const messages2 = SynthUtils.synthesize(nonCompliant2).messages;
+    expect(messages2).toContainEqual(
+      expect.objectContaining({
+        entry: expect.objectContaining({
+          data: expect.stringContaining(
+            'NIST.800.53.R5-SecretsManagerRotationEnabled:'
+          ),
+        }),
+      })
+    );
+
+    const nonCompliant3 = new Stack();
+    Aspects.of(nonCompliant3).add(new NIST80053R5Checks());
+    new CfnRotationSchedule(nonCompliant3, 'rRotationSchedule', {
+      secretId: new CfnSecretTargetAttachment(
+        nonCompliant3,
+        'rCfnTargetAttachment',
+        {
+          secretId: new Secret(nonCompliant3, 'rSecret').secretArn,
+          targetId: 'foo',
+          targetType: 'bar',
+        }
+      ).ref,
+      rotationRules: {
+        automaticallyAfterDays: 42,
+      },
+    });
+    const messages3 = SynthUtils.synthesize(nonCompliant3).messages;
+    expect(messages3).toContainEqual(
+      expect.objectContaining({
+        entry: expect.objectContaining({
+          data: expect.stringContaining(
+            'NIST.800.53.R5-SecretsManagerRotationEnabled:'
+          ),
+        }),
+      })
+    );
+
     const compliant = new Stack();
     Aspects.of(compliant).add(new NIST80053R5Checks());
     new Secret(compliant, 'rSecret1').addRotationSchedule(
@@ -37,8 +96,23 @@ describe('AWS Secrets Manager', () => {
         automaticallyAfter: Duration.days(30),
       }
     );
-    const messages2 = SynthUtils.synthesize(compliant).messages;
-    expect(messages2).not.toContainEqual(
+    new CfnRotationSchedule(compliant, 'rRotationSchedule3', {
+      secretId: new CfnSecretTargetAttachment(
+        compliant,
+        'rCfnTargetAttachment',
+        {
+          secretId: new Secret(compliant, 'rSecret3').secretArn,
+          targetId: 'foo',
+          targetType: 'bar',
+        }
+      ).ref,
+      rotationLambdaArn: 'baz',
+      rotationRules: {
+        automaticallyAfterDays: 42,
+      },
+    });
+    const messages4 = SynthUtils.synthesize(compliant).messages;
+    expect(messages4).not.toContainEqual(
       expect.objectContaining({
         entry: expect.objectContaining({
           data: expect.stringContaining(


### PR DESCRIPTION

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*