### PR TITLE
chore: align major version with cdk major version

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,7 @@ jobs:
     env:
       CI: "true"
       RELEASE: "true"
+      MAJOR: 1
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -186,7 +186,8 @@
       "name": "release",
       "description": "Prepare a release from \"main\" branch",
       "env": {
-        "RELEASE": "true"
+        "RELEASE": "true",
+        "MAJOR": "1"
       },
       "steps": [
         {

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -2,20 +2,17 @@
 Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
-const {
-  AwsCdkConstructLibrary,
-  DependenciesUpgradeMechanism,
-} = require('projen');
+const { AwsCdkConstructLibrary } = require('projen');
 const project = new AwsCdkConstructLibrary({
   author: 'Arun Donti',
   authorAddress: 'donti@amazon.com',
   cdkVersion: '1.123.0',
   defaultReleaseBranch: 'main',
+  majorVersion: 1,
   name: 'cdk-nag',
   description:
     'Check CDK applications for best practices using a combination on available rule packs.',
   repositoryUrl: 'https://github.com/cdklabs/cdk-nag.git',
-
   cdkDependencies: [
     '@aws-cdk/aws-apigateway',
     '@aws-cdk/aws-apigatewayv2',
@@ -198,6 +195,7 @@ project.release.addJobs({
     env: {
       CI: 'true',
       RELEASE: 'true',
+      MAJOR: 1,
     },
     steps: [
       {

--- a/README.md
+++ b/README.md
@@ -10,7 +10,9 @@ SPDX-License-Identifier: Apache-2.0
 | Python     | [![PyPI version](https://badge.fury.io/py/cdk-nag.svg)](https://badge.fury.io/py/cdk-nag) | [![PyPI version](https://badge.fury.io/py/monocdk-nag.svg)](https://badge.fury.io/py/monocdk-nag) |
 | TypeScript | [![npm version](https://badge.fury.io/js/cdk-nag.svg)](https://badge.fury.io/js/cdk-nag)  | [![npm version](https://badge.fury.io/js/monocdk-nag.svg)](https://badge.fury.io/js/monocdk-nag)  |
 
-**Note**: Read the [usage](#usage) section for details on how to use for your intended cdk version (CDK v1, CDK v2, monocdk)
+- If your project uses cdk version **1.x.x** use `cdk-nag` **^1.0.0**
+- If your project uses cdk version **2.x.x** use `cdk-nag` **^2.0.0**
+- If your project uses monocdk use `monocdk-nag` **^1.0.0**
 
 Check CDK applications or [CloudFormation templates](#using-on-cloudformation-templates) for best practices using a combination of available rule packs. Inspired by [cfn_nag](https://github.com/stelligent/cfn_nag)
 
@@ -31,16 +33,6 @@ See [RULES](./RULES.md) for more information on all the available packs.
 <details>
 <summary>cdk</summary>
 
-Specify a major version of greater than `0` in your dependencies
-
-```json
-{
-  "dependencies": {
-    "cdk-nag": "^0.2.0"
-  }
-}
-```
-
 ```typescript
 import { App, Aspects } from '@aws-cdk/core';
 import { CdkTestStack } from '../lib/cdk-test-stack';
@@ -59,16 +51,6 @@ Aspects.of(app).add(new AwsSolutionsChecks());
 <details>
 <summary>cdk v2</summary>
 
-Specify a major version of greater than `2` in your dependencies
-
-```json
-{
-  "dependencies": {
-    "cdk-nag": "^2.0.0"
-  }
-}
-```
-
 ```typescript
 import { App, Aspects } from 'aws-cdk-lib';
 import { CdkTestStack } from '../lib/cdk-test-stack';
@@ -86,16 +68,6 @@ Aspects.of(app).add(new AwsSolutionsChecks());
 
 <details>
 <summary>monocdk</summary>
-
-Specify a major version of greater than `0` in your dependencies
-
-```json
-{
-  "dependencies": {
-    "monocdk-nag": "^0.2.0"
-  }
-}
-```
 
 ```typescript
 import { App, Aspects } from 'monocdk';

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ SPDX-License-Identifier: Apache-2.0
 | Python     | [![PyPI version](https://badge.fury.io/py/cdk-nag.svg)](https://badge.fury.io/py/cdk-nag) | [![PyPI version](https://badge.fury.io/py/monocdk-nag.svg)](https://badge.fury.io/py/monocdk-nag) |
 | TypeScript | [![npm version](https://badge.fury.io/js/cdk-nag.svg)](https://badge.fury.io/js/cdk-nag)  | [![npm version](https://badge.fury.io/js/monocdk-nag.svg)](https://badge.fury.io/js/monocdk-nag)  |
 
+**Note**: Read the [usage](#usage) section for details on how to use for your intended cdk version (CDK v1, CDK v2, monocdk)
+
 Check CDK applications or [CloudFormation templates](#using-on-cloudformation-templates) for best practices using a combination of available rule packs. Inspired by [cfn_nag](https://github.com/stelligent/cfn_nag)
 
 ![](cdk_nag.gif)
@@ -26,7 +28,18 @@ See [RULES](./RULES.md) for more information on all the available packs.
 
 ## Usage
 
-### cdk
+<details>
+<summary>cdk</summary>
+
+Specify a major version of greater than `0` in your dependencies
+
+```json
+{
+  "dependencies": {
+    "cdk-nag": "^0.2.0"
+  }
+}
+```
 
 ```typescript
 import { App, Aspects } from '@aws-cdk/core';
@@ -41,7 +54,48 @@ Aspects.of(app).add(new AwsSolutionsChecks());
 // Aspects.of(stack).add(new AwsSolutionsChecks({ verbose: true }));
 ```
 
-### monocdk
+</details>
+
+<details>
+<summary>cdk v2</summary>
+
+Specify a major version of greater than `2` in your dependencies
+
+```json
+{
+  "dependencies": {
+    "cdk-nag": "^2.0.0"
+  }
+}
+```
+
+```typescript
+import { App, Aspects } from 'aws-cdk-lib';
+import { CdkTestStack } from '../lib/cdk-test-stack';
+import { AwsSolutionsChecks } from 'cdk-nag';
+
+const app = new App();
+new CdkTestStack(app, 'CdkNagDemo');
+// Simple rule informational messages
+Aspects.of(app).add(new AwsSolutionsChecks());
+// Additional explanations on the purpose of triggered rules
+// Aspects.of(stack).add(new AwsSolutionsChecks({ verbose: true }));
+```
+
+</details>
+
+<details>
+<summary>monocdk</summary>
+
+Specify a major version of greater than `0` in your dependencies
+
+```json
+{
+  "dependencies": {
+    "monocdk-nag": "^0.2.0"
+  }
+}
+```
 
 ```typescript
 import { App, Aspects } from 'monocdk';
@@ -55,6 +109,8 @@ Aspects.of(app).add(new AwsSolutionsChecks());
 // Additional explanations on the purpose of triggered rules
 // Aspects.of(stack).add(new AwsSolutionsChecks({ verbose: true }));
 ```
+
+</details>
 
 ## Suppressing a Rule
 


### PR DESCRIPTION
Updating the major version of releases for  `cdkv1` and `monocdk` to use the major version `1`. This is due to releasing `cdk-nag` for `cdkv2` and wanting clarity around which version to use for the corresponding cdk

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*