### PR TITLE
feat(Nag Pack): compliance reports

### DIFF
--- a/.projenrc.js
+++ b/.projenrc.js
@@ -105,6 +105,7 @@ const project = new AwsCdkConstructLibrary({
 });
 project.package.addField('resolutions', {
   'ansi-regex': '^5.0.1',
+  'json-schema': '^0.4.0',
 });
 project.package.addField('prettier', {
   singleQuote: true,

--- a/API.md
+++ b/API.md
@@ -33,6 +33,7 @@ Name|Description
 Name|Description
 ----|-----------
 [NagMessageLevel](#cdk-nag-nagmessagelevel)|The level of the message that the rule applies.
+[NagRuleCompliance](#cdk-nag-nagrulecompliance)|The compliance level of a resource in relation to a rule.
 
 
 
@@ -54,6 +55,7 @@ new AwsSolutionsChecks(props?: NagPackProps)
 
 * **props** (<code>[NagPackProps](#cdk-nag-nagpackprops)</code>)  *No description*
   * **logIgnores** (<code>boolean</code>)  Whether or not to log triggered rules that have been suppressed as informational messages (default: false). __*Optional*__
+  * **reports** (<code>boolean</code>)  Whether or not to generate CSV compliance reports for applied Stacks (default: false). __*Optional*__
   * **verbose** (<code>boolean</code>)  Whether or not to enable extended explanatory descriptions on warning, error, and logged ignore messages (default: false). __*Optional*__
 
 
@@ -95,6 +97,7 @@ new HIPAASecurityChecks(props?: NagPackProps)
 
 * **props** (<code>[NagPackProps](#cdk-nag-nagpackprops)</code>)  *No description*
   * **logIgnores** (<code>boolean</code>)  Whether or not to log triggered rules that have been suppressed as informational messages (default: false). __*Optional*__
+  * **reports** (<code>boolean</code>)  Whether or not to generate CSV compliance reports for applied Stacks (default: false). __*Optional*__
   * **verbose** (<code>boolean</code>)  Whether or not to enable extended explanatory descriptions on warning, error, and logged ignore messages (default: false). __*Optional*__
 
 
@@ -136,6 +139,7 @@ new NIST80053R4Checks(props?: NagPackProps)
 
 * **props** (<code>[NagPackProps](#cdk-nag-nagpackprops)</code>)  *No description*
   * **logIgnores** (<code>boolean</code>)  Whether or not to log triggered rules that have been suppressed as informational messages (default: false). __*Optional*__
+  * **reports** (<code>boolean</code>)  Whether or not to generate CSV compliance reports for applied Stacks (default: false). __*Optional*__
   * **verbose** (<code>boolean</code>)  Whether or not to enable extended explanatory descriptions on warning, error, and logged ignore messages (default: false). __*Optional*__
 
 
@@ -177,6 +181,7 @@ new NIST80053R5Checks(props?: NagPackProps)
 
 * **props** (<code>[NagPackProps](#cdk-nag-nagpackprops)</code>)  *No description*
   * **logIgnores** (<code>boolean</code>)  Whether or not to log triggered rules that have been suppressed as informational messages (default: false). __*Optional*__
+  * **reports** (<code>boolean</code>)  Whether or not to generate CSV compliance reports for applied Stacks (default: false). __*Optional*__
   * **verbose** (<code>boolean</code>)  Whether or not to enable extended explanatory descriptions on warning, error, and logged ignore messages (default: false). __*Optional*__
 
 
@@ -216,6 +221,7 @@ new NagPack(props?: NagPackProps)
 
 * **props** (<code>[NagPackProps](#cdk-nag-nagpackprops)</code>)  *No description*
   * **logIgnores** (<code>boolean</code>)  Whether or not to log triggered rules that have been suppressed as informational messages (default: false). __*Optional*__
+  * **reports** (<code>boolean</code>)  Whether or not to generate CSV compliance reports for applied Stacks (default: false). __*Optional*__
   * **verbose** (<code>boolean</code>)  Whether or not to enable extended explanatory descriptions on warning, error, and logged ignore messages (default: false). __*Optional*__
 
 
@@ -228,22 +234,12 @@ Name | Type | Description
 **logIgnores** | <code>boolean</code> | <span></span>
 **packName** | <code>string</code> | <span></span>
 **readPackName** | <code>string</code> | <span></span>
+**readReportStacks** | <code>Array<string></code> | <span></span>
+**reportStacks** | <code>Array<string></code> | <span></span>
+**reports** | <code>boolean</code> | <span></span>
 **verbose** | <code>boolean</code> | <span></span>
 
 ### Methods
-
-
-#### applyRule(params) <a id="cdk-nag-nagpack-applyrule"></a>
-
-Create a rule to be used in the NagPack.
-
-```ts
-applyRule(params: IApplyRule): void
-```
-
-* **params** (<code>[IApplyRule](#cdk-nag-iapplyrule)</code>)  The.
-
-
 
 
 #### visit(node) <a id="cdk-nag-nagpack-visit"></a>
@@ -255,6 +251,80 @@ visit(node: IConstruct): void
 ```
 
 * **node** (<code>[IConstruct](#aws-cdk-core-iconstruct)</code>)  *No description*
+
+
+
+
+#### protected applyRule(params) <a id="cdk-nag-nagpack-applyrule"></a>
+
+Create a rule to be used in the NagPack.
+
+```ts
+protected applyRule(params: IApplyRule): void
+```
+
+* **params** (<code>[IApplyRule](#cdk-nag-iapplyrule)</code>)  The.
+
+
+
+
+#### protected createComplianceReportLine(params, ruleId, compliance, explanation?) <a id="cdk-nag-nagpack-createcompliancereportline"></a>
+
+Helper function to create a line for the compliance report.
+
+```ts
+protected createComplianceReportLine(params: IApplyRule, ruleId: string, compliance: NagRuleCompliance &#124; string, explanation?: string): string
+```
+
+* **params** (<code>[IApplyRule](#cdk-nag-iapplyrule)</code>)  The.
+* **ruleId** (<code>string</code>)  The id of the rule.
+* **compliance** (<code>[NagRuleCompliance](#cdk-nag-nagrulecompliance) &#124; string</code>)  The compliance status of the rule.
+* **explanation** (<code>string</code>)  The explanation for suppressed rules.
+
+__Returns__:
+* <code>string</code>
+
+#### protected createMessage(ruleId, info, explanation) <a id="cdk-nag-nagpack-createmessage"></a>
+
+The message to output to the console when a rule is triggered.
+
+```ts
+protected createMessage(ruleId: string, info: string, explanation: string): string
+```
+
+* **ruleId** (<code>string</code>)  The id of the rule.
+* **info** (<code>string</code>)  Why the rule was triggered.
+* **explanation** (<code>string</code>)  Why the rule exists.
+
+__Returns__:
+* <code>string</code>
+
+#### protected ignoreRule(ignores, ruleId) <a id="cdk-nag-nagpack-ignorerule"></a>
+
+Check whether a specific rule should be ignored.
+
+```ts
+protected ignoreRule(ignores: Array<NagPackSuppression>, ruleId: string): string
+```
+
+* **ignores** (<code>Array<[NagPackSuppression](#cdk-nag-nagpacksuppression)></code>)  The ignores listed in cdk-nag metadata.
+* **ruleId** (<code>string</code>)  The id of the rule to ignore.
+
+__Returns__:
+* <code>string</code>
+
+#### protected writeToStackComplianceReport(params, ruleId, compliance, explanation?) <a id="cdk-nag-nagpack-writetostackcompliancereport"></a>
+
+Write a line to the rule packs compliance report for the resource's Stack.
+
+```ts
+protected writeToStackComplianceReport(params: IApplyRule, ruleId: string, compliance: NagRuleCompliance &#124; string, explanation?: string): void
+```
+
+* **params** (<code>[IApplyRule](#cdk-nag-iapplyrule)</code>)  The.
+* **ruleId** (<code>string</code>)  The id of the rule.
+* **compliance** (<code>[NagRuleCompliance](#cdk-nag-nagrulecompliance) &#124; string</code>)  The compliance status of the rule.
+* **explanation** (<code>string</code>)  The explanation for suppressed rules.
 
 
 
@@ -346,6 +416,7 @@ new PCIDSS321Checks(props?: NagPackProps)
 
 * **props** (<code>[NagPackProps](#cdk-nag-nagpackprops)</code>)  *No description*
   * **logIgnores** (<code>boolean</code>)  Whether or not to log triggered rules that have been suppressed as informational messages (default: false). __*Optional*__
+  * **reports** (<code>boolean</code>)  Whether or not to generate CSV compliance reports for applied Stacks (default: false). __*Optional*__
   * **verbose** (<code>boolean</code>)  Whether or not to enable extended explanatory descriptions on warning, error, and logged ignore messages (default: false). __*Optional*__
 
 
@@ -391,13 +462,13 @@ Name | Type | Description
 The callback to the rule.
 
 ```ts
-rule(node: CfnResource): boolean
+rule(node: CfnResource): NagRuleCompliance
 ```
 
 * **node** (<code>[CfnResource](#aws-cdk-core-cfnresource)</code>)  The CfnResource to check.
 
 __Returns__:
-* <code>boolean</code>
+* <code>[NagRuleCompliance](#cdk-nag-nagrulecompliance)</code>
 
 
 
@@ -411,6 +482,7 @@ Interface for creating a Nag rule pack.
 Name | Type | Description 
 -----|------|-------------
 **logIgnores**? | <code>boolean</code> | Whether or not to log triggered rules that have been suppressed as informational messages (default: false).<br/>__*Optional*__
+**reports**? | <code>boolean</code> | Whether or not to generate CSV compliance reports for applied Stacks (default: false).<br/>__*Optional*__
 **verbose**? | <code>boolean</code> | Whether or not to enable extended explanatory descriptions on warning, error, and logged ignore messages (default: false).<br/>__*Optional*__
 
 
@@ -437,5 +509,16 @@ Name | Description
 -----|-----
 **WARN** |
 **ERROR** |
+
+
+## enum NagRuleCompliance  <a id="cdk-nag-nagrulecompliance"></a>
+
+The compliance level of a resource in relation to a rule.
+
+Name | Description
+-----|-----
+**COMPLIANT** |
+**NON_COMPLIANT** |
+**NOT_APPLICABLE** |
 
 

--- a/API.md
+++ b/API.md
@@ -55,7 +55,7 @@ new AwsSolutionsChecks(props?: NagPackProps)
 
 * **props** (<code>[NagPackProps](#cdk-nag-nagpackprops)</code>)  *No description*
   * **logIgnores** (<code>boolean</code>)  Whether or not to log triggered rules that have been suppressed as informational messages (default: false). __*Optional*__
-  * **reports** (<code>boolean</code>)  Whether or not to generate CSV compliance reports for applied Stacks (default: false). __*Optional*__
+  * **reports** (<code>boolean</code>)  Whether or not to generate CSV compliance reports for applied Stacks in the App's output directory (default: false). __*Optional*__
   * **verbose** (<code>boolean</code>)  Whether or not to enable extended explanatory descriptions on warning, error, and logged ignore messages (default: false). __*Optional*__
 
 
@@ -97,7 +97,7 @@ new HIPAASecurityChecks(props?: NagPackProps)
 
 * **props** (<code>[NagPackProps](#cdk-nag-nagpackprops)</code>)  *No description*
   * **logIgnores** (<code>boolean</code>)  Whether or not to log triggered rules that have been suppressed as informational messages (default: false). __*Optional*__
-  * **reports** (<code>boolean</code>)  Whether or not to generate CSV compliance reports for applied Stacks (default: false). __*Optional*__
+  * **reports** (<code>boolean</code>)  Whether or not to generate CSV compliance reports for applied Stacks in the App's output directory (default: false). __*Optional*__
   * **verbose** (<code>boolean</code>)  Whether or not to enable extended explanatory descriptions on warning, error, and logged ignore messages (default: false). __*Optional*__
 
 
@@ -139,7 +139,7 @@ new NIST80053R4Checks(props?: NagPackProps)
 
 * **props** (<code>[NagPackProps](#cdk-nag-nagpackprops)</code>)  *No description*
   * **logIgnores** (<code>boolean</code>)  Whether or not to log triggered rules that have been suppressed as informational messages (default: false). __*Optional*__
-  * **reports** (<code>boolean</code>)  Whether or not to generate CSV compliance reports for applied Stacks (default: false). __*Optional*__
+  * **reports** (<code>boolean</code>)  Whether or not to generate CSV compliance reports for applied Stacks in the App's output directory (default: false). __*Optional*__
   * **verbose** (<code>boolean</code>)  Whether or not to enable extended explanatory descriptions on warning, error, and logged ignore messages (default: false). __*Optional*__
 
 
@@ -181,7 +181,7 @@ new NIST80053R5Checks(props?: NagPackProps)
 
 * **props** (<code>[NagPackProps](#cdk-nag-nagpackprops)</code>)  *No description*
   * **logIgnores** (<code>boolean</code>)  Whether or not to log triggered rules that have been suppressed as informational messages (default: false). __*Optional*__
-  * **reports** (<code>boolean</code>)  Whether or not to generate CSV compliance reports for applied Stacks (default: false). __*Optional*__
+  * **reports** (<code>boolean</code>)  Whether or not to generate CSV compliance reports for applied Stacks in the App's output directory (default: false). __*Optional*__
   * **verbose** (<code>boolean</code>)  Whether or not to enable extended explanatory descriptions on warning, error, and logged ignore messages (default: false). __*Optional*__
 
 
@@ -221,7 +221,7 @@ new NagPack(props?: NagPackProps)
 
 * **props** (<code>[NagPackProps](#cdk-nag-nagpackprops)</code>)  *No description*
   * **logIgnores** (<code>boolean</code>)  Whether or not to log triggered rules that have been suppressed as informational messages (default: false). __*Optional*__
-  * **reports** (<code>boolean</code>)  Whether or not to generate CSV compliance reports for applied Stacks (default: false). __*Optional*__
+  * **reports** (<code>boolean</code>)  Whether or not to generate CSV compliance reports for applied Stacks in the App's output directory (default: false). __*Optional*__
   * **verbose** (<code>boolean</code>)  Whether or not to enable extended explanatory descriptions on warning, error, and logged ignore messages (default: false). __*Optional*__
 
 
@@ -416,7 +416,7 @@ new PCIDSS321Checks(props?: NagPackProps)
 
 * **props** (<code>[NagPackProps](#cdk-nag-nagpackprops)</code>)  *No description*
   * **logIgnores** (<code>boolean</code>)  Whether or not to log triggered rules that have been suppressed as informational messages (default: false). __*Optional*__
-  * **reports** (<code>boolean</code>)  Whether or not to generate CSV compliance reports for applied Stacks (default: false). __*Optional*__
+  * **reports** (<code>boolean</code>)  Whether or not to generate CSV compliance reports for applied Stacks in the App's output directory (default: false). __*Optional*__
   * **verbose** (<code>boolean</code>)  Whether or not to enable extended explanatory descriptions on warning, error, and logged ignore messages (default: false). __*Optional*__
 
 
@@ -482,7 +482,7 @@ Interface for creating a Nag rule pack.
 Name | Type | Description 
 -----|------|-------------
 **logIgnores**? | <code>boolean</code> | Whether or not to log triggered rules that have been suppressed as informational messages (default: false).<br/>__*Optional*__
-**reports**? | <code>boolean</code> | Whether or not to generate CSV compliance reports for applied Stacks (default: false).<br/>__*Optional*__
+**reports**? | <code>boolean</code> | Whether or not to generate CSV compliance reports for applied Stacks in the App's output directory (default: false).<br/>__*Optional*__
 **verbose**? | <code>boolean</code> | Whether or not to enable extended explanatory descriptions on warning, error, and logged ignore messages (default: false).<br/>__*Optional*__
 
 

--- a/API.md
+++ b/API.md
@@ -55,7 +55,7 @@ new AwsSolutionsChecks(props?: NagPackProps)
 
 * **props** (<code>[NagPackProps](#cdk-nag-nagpackprops)</code>)  *No description*
   * **logIgnores** (<code>boolean</code>)  Whether or not to log triggered rules that have been suppressed as informational messages (default: false). __*Optional*__
-  * **reports** (<code>boolean</code>)  Whether or not to generate CSV compliance reports for applied Stacks in the App's output directory (default: false). __*Optional*__
+  * **reports** (<code>boolean</code>)  Whether or not to generate CSV compliance reports for applied Stacks in the App's output directory (default: true). __*Optional*__
   * **verbose** (<code>boolean</code>)  Whether or not to enable extended explanatory descriptions on warning, error, and logged ignore messages (default: false). __*Optional*__
 
 
@@ -97,7 +97,7 @@ new HIPAASecurityChecks(props?: NagPackProps)
 
 * **props** (<code>[NagPackProps](#cdk-nag-nagpackprops)</code>)  *No description*
   * **logIgnores** (<code>boolean</code>)  Whether or not to log triggered rules that have been suppressed as informational messages (default: false). __*Optional*__
-  * **reports** (<code>boolean</code>)  Whether or not to generate CSV compliance reports for applied Stacks in the App's output directory (default: false). __*Optional*__
+  * **reports** (<code>boolean</code>)  Whether or not to generate CSV compliance reports for applied Stacks in the App's output directory (default: true). __*Optional*__
   * **verbose** (<code>boolean</code>)  Whether or not to enable extended explanatory descriptions on warning, error, and logged ignore messages (default: false). __*Optional*__
 
 
@@ -139,7 +139,7 @@ new NIST80053R4Checks(props?: NagPackProps)
 
 * **props** (<code>[NagPackProps](#cdk-nag-nagpackprops)</code>)  *No description*
   * **logIgnores** (<code>boolean</code>)  Whether or not to log triggered rules that have been suppressed as informational messages (default: false). __*Optional*__
-  * **reports** (<code>boolean</code>)  Whether or not to generate CSV compliance reports for applied Stacks in the App's output directory (default: false). __*Optional*__
+  * **reports** (<code>boolean</code>)  Whether or not to generate CSV compliance reports for applied Stacks in the App's output directory (default: true). __*Optional*__
   * **verbose** (<code>boolean</code>)  Whether or not to enable extended explanatory descriptions on warning, error, and logged ignore messages (default: false). __*Optional*__
 
 
@@ -181,7 +181,7 @@ new NIST80053R5Checks(props?: NagPackProps)
 
 * **props** (<code>[NagPackProps](#cdk-nag-nagpackprops)</code>)  *No description*
   * **logIgnores** (<code>boolean</code>)  Whether or not to log triggered rules that have been suppressed as informational messages (default: false). __*Optional*__
-  * **reports** (<code>boolean</code>)  Whether or not to generate CSV compliance reports for applied Stacks in the App's output directory (default: false). __*Optional*__
+  * **reports** (<code>boolean</code>)  Whether or not to generate CSV compliance reports for applied Stacks in the App's output directory (default: true). __*Optional*__
   * **verbose** (<code>boolean</code>)  Whether or not to enable extended explanatory descriptions on warning, error, and logged ignore messages (default: false). __*Optional*__
 
 
@@ -221,7 +221,7 @@ new NagPack(props?: NagPackProps)
 
 * **props** (<code>[NagPackProps](#cdk-nag-nagpackprops)</code>)  *No description*
   * **logIgnores** (<code>boolean</code>)  Whether or not to log triggered rules that have been suppressed as informational messages (default: false). __*Optional*__
-  * **reports** (<code>boolean</code>)  Whether or not to generate CSV compliance reports for applied Stacks in the App's output directory (default: false). __*Optional*__
+  * **reports** (<code>boolean</code>)  Whether or not to generate CSV compliance reports for applied Stacks in the App's output directory (default: true). __*Optional*__
   * **verbose** (<code>boolean</code>)  Whether or not to enable extended explanatory descriptions on warning, error, and logged ignore messages (default: false). __*Optional*__
 
 
@@ -416,7 +416,7 @@ new PCIDSS321Checks(props?: NagPackProps)
 
 * **props** (<code>[NagPackProps](#cdk-nag-nagpackprops)</code>)  *No description*
   * **logIgnores** (<code>boolean</code>)  Whether or not to log triggered rules that have been suppressed as informational messages (default: false). __*Optional*__
-  * **reports** (<code>boolean</code>)  Whether or not to generate CSV compliance reports for applied Stacks in the App's output directory (default: false). __*Optional*__
+  * **reports** (<code>boolean</code>)  Whether or not to generate CSV compliance reports for applied Stacks in the App's output directory (default: true). __*Optional*__
   * **verbose** (<code>boolean</code>)  Whether or not to enable extended explanatory descriptions on warning, error, and logged ignore messages (default: false). __*Optional*__
 
 
@@ -482,7 +482,7 @@ Interface for creating a Nag rule pack.
 Name | Type | Description 
 -----|------|-------------
 **logIgnores**? | <code>boolean</code> | Whether or not to log triggered rules that have been suppressed as informational messages (default: false).<br/>__*Optional*__
-**reports**? | <code>boolean</code> | Whether or not to generate CSV compliance reports for applied Stacks in the App's output directory (default: false).<br/>__*Optional*__
+**reports**? | <code>boolean</code> | Whether or not to generate CSV compliance reports for applied Stacks in the App's output directory (default: true).<br/>__*Optional*__
 **verbose**? | <code>boolean</code> | Whether or not to enable extended explanatory descriptions on warning, error, and logged ignore messages (default: false).<br/>__*Optional*__
 
 

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ See [RULES](./RULES.md) for more information on all the available packs.
 
 ## Usage
 
+For a full list of options See `NagPackProps` in the [API.md](./API.md#struct-nagpackprops)
+
 <details>
 <summary>cdk</summary>
 

--- a/package.json
+++ b/package.json
@@ -240,7 +240,8 @@
     }
   },
   "resolutions": {
-    "ansi-regex": "^5.0.1"
+    "ansi-regex": "^5.0.1",
+    "json-schema": "^0.4.0"
   },
   "prettier": {
     "singleQuote": true,

--- a/src/nag-pack.ts
+++ b/src/nag-pack.ts
@@ -2,6 +2,7 @@
 Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
+import { appendFileSync, writeFileSync } from 'fs';
 import {
   IAspect,
   IConstruct,
@@ -27,6 +28,11 @@ export interface NagPackProps {
    * Whether or not to log triggered rules that have been suppressed as informational messages (default: false).
    */
   readonly logIgnores?: boolean;
+
+  /**
+   * Whether or not to generate CSV compliance reports for applied Stacks (default: false).
+   */
+  readonly reports?: boolean;
 }
 
 /**
@@ -57,15 +63,24 @@ export interface IApplyRule {
    * The callback to the rule.
    * @param node The CfnResource to check.
    */
-  rule(node: CfnResource): boolean;
+  rule(node: CfnResource): NagRuleCompliance;
 }
 
 /**
  * The level of the message that the rule applies.
  */
 export enum NagMessageLevel {
-  WARN,
-  ERROR,
+  WARN = 'Warning',
+  ERROR = 'Error',
+}
+
+/**
+ * The compliance level of a resource in relation to a rule.
+ */
+export enum NagRuleCompliance {
+  COMPLIANT = 'Compliant',
+  NON_COMPLIANT = 'Non-Compliant',
+  NOT_APPLICABLE = 'N/A',
 }
 
 /**
@@ -74,6 +89,8 @@ export enum NagMessageLevel {
 export abstract class NagPack implements IAspect {
   protected verbose: boolean;
   protected logIgnores: boolean;
+  protected reports: boolean;
+  protected reportStacks = new Array<string>();
   protected packName = '';
 
   constructor(props?: NagPackProps) {
@@ -83,10 +100,15 @@ export abstract class NagPack implements IAspect {
       props == undefined || props.logIgnores == undefined
         ? false
         : props.logIgnores;
+    this.reports =
+      props == undefined || props.reports == undefined ? false : props.reports;
   }
 
   public get readPackName(): string {
     return this.packName;
+  }
+  public get readReportStacks(): string[] {
+    return this.reportStacks;
   }
   /**
    * All aspects can visit an IConstruct.
@@ -97,7 +119,7 @@ export abstract class NagPack implements IAspect {
    * Create a rule to be used in the NagPack.
    * @param params The @IApplyRule interface with rule details.
    */
-  public applyRule(params: IApplyRule): void {
+  protected applyRule(params: IApplyRule): void {
     if (this.packName === '') {
       throw Error(
         'The NagPack does not have a pack name, therefore the rule could not be applied. Set a packName in the NagPack constructor.'
@@ -114,8 +136,22 @@ export abstract class NagPack implements IAspect {
       : params.rule.name;
     const ruleId = `${this.packName}-${ruleSuffix}`;
     try {
-      if (!params.rule(params.node)) {
+      const ruleCompliance = params.rule(params.node);
+      if (
+        this.reports === true &&
+        ruleCompliance === NagRuleCompliance.COMPLIANT
+      ) {
+        this.writeToStackComplianceReport(params, ruleId, ruleCompliance);
+      } else if (ruleCompliance === NagRuleCompliance.NON_COMPLIANT) {
         const reason = this.ignoreRule(allIgnores, ruleId);
+        if (this.reports === true) {
+          this.writeToStackComplianceReport(
+            params,
+            ruleId,
+            ruleCompliance,
+            reason
+          );
+        }
         if (reason) {
           if (this.logIgnores === true) {
             const message = this.createMessage(
@@ -140,6 +176,9 @@ export abstract class NagPack implements IAspect {
       }
     } catch (error) {
       const reason = this.ignoreRule(allIgnores, VALIDATION_FAILURE_ID);
+      if (this.reports === true) {
+        this.writeToStackComplianceReport(params, ruleId, 'UNKNOWN', reason);
+      }
       if (reason) {
         if (this.logIgnores === true) {
           const message = this.createMessage(
@@ -167,7 +206,7 @@ export abstract class NagPack implements IAspect {
    * @param ruleId The id of the rule to ignore.
    * @returns The reason the rule was ignored, or an empty string.
    */
-  private ignoreRule(ignores: NagPackSuppression[], ruleId: string): string {
+  protected ignoreRule(ignores: NagPackSuppression[], ruleId: string): string {
     for (let ignore of ignores) {
       if (
         ignore.id &&
@@ -195,13 +234,81 @@ export abstract class NagPack implements IAspect {
    * @param explanation Why the rule exists.
    * @returns The formatted message string.
    */
-  private createMessage(
+  protected createMessage(
     ruleId: string,
     info: string,
     explanation: string
   ): string {
     let message = `${ruleId}: ${info}`;
     return this.verbose ? `${message} ${explanation}\n` : `${message}\n`;
+  }
+
+  /**
+   * Write a line to the rule packs compliance report for the resource's Stack
+   * @param params The @IApplyRule interface with rule details.
+   * @param ruleId The id of the rule.
+   * @param compliance The compliance status of the rule.
+   * @param explanation The explanation for suppressed rules.
+   */
+  protected writeToStackComplianceReport(
+    params: IApplyRule,
+    ruleId: string,
+    compliance:
+      | NagRuleCompliance.COMPLIANT
+      | NagRuleCompliance.NON_COMPLIANT
+      | 'UNKNOWN',
+    explanation: string = ''
+  ): void {
+    const line = this.createComplianceReportLine(
+      params,
+      ruleId,
+      compliance,
+      explanation
+    );
+    const fileName = `${this.packName}-${params.node.stack.stackName}-NagReport.csv`;
+    if (!this.reportStacks.includes(fileName)) {
+      this.reportStacks.push(fileName);
+      writeFileSync(
+        fileName,
+        'Rule ID,Resource ID,Compliance,Exception Reason,Rule Level\n'
+      );
+    }
+    appendFileSync(fileName, line);
+  }
+
+  /**
+   * Helper function to create a line for the compliance report
+   * @param params The @IApplyRule interface with rule details.
+   * @param ruleId The id of the rule.
+   * @param compliance The compliance status of the rule.
+   * @param explanation The explanation for suppressed rules.
+   */
+  protected createComplianceReportLine(
+    params: IApplyRule,
+    ruleId: string,
+    compliance:
+      | NagRuleCompliance.COMPLIANT
+      | NagRuleCompliance.NON_COMPLIANT
+      | 'UNKNOWN',
+    explanation: string = ''
+  ): string {
+    //| Rule ID | Resource ID | Compliance | Exception Reason | Rule Level
+    const line = Array<string>();
+    line.push(ruleId);
+    line.push(params.node.node.path);
+    if (
+      (compliance === NagRuleCompliance.NON_COMPLIANT ||
+        compliance === 'UNKNOWN') &&
+      explanation !== ''
+    ) {
+      line.push('Suppressed');
+      line.push(explanation);
+    } else {
+      line.push(compliance);
+      line.push('N/A');
+    }
+    line.push(params.level);
+    return line.join(',') + '\n';
   }
 }
 

--- a/src/nag-pack.ts
+++ b/src/nag-pack.ts
@@ -3,12 +3,14 @@ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 import { appendFileSync, writeFileSync } from 'fs';
+import { join } from 'path';
 import {
   IAspect,
   IConstruct,
   Annotations,
   CfnResource,
   Stack,
+  App,
 } from '@aws-cdk/core';
 import { NagPackSuppression } from './nag-suppressions';
 
@@ -30,7 +32,7 @@ export interface NagPackProps {
   readonly logIgnores?: boolean;
 
   /**
-   * Whether or not to generate CSV compliance reports for applied Stacks (default: false).
+   * Whether or not to generate CSV compliance reports for applied Stacks in the App's output directory (default: false).
    */
   readonly reports?: boolean;
 }
@@ -265,15 +267,17 @@ export abstract class NagPack implements IAspect {
       compliance,
       explanation
     );
+    let outDir = App.of(params.node)?.outdir;
     const fileName = `${this.packName}-${params.node.stack.stackName}-NagReport.csv`;
+    const filePath = join(outDir ? outDir : '', fileName);
     if (!this.reportStacks.includes(fileName)) {
       this.reportStacks.push(fileName);
       writeFileSync(
-        fileName,
+        filePath,
         'Rule ID,Resource ID,Compliance,Exception Reason,Rule Level\n'
       );
     }
-    appendFileSync(fileName, line);
+    appendFileSync(filePath, line);
   }
 
   /**

--- a/src/nag-pack.ts
+++ b/src/nag-pack.ts
@@ -312,7 +312,7 @@ export abstract class NagPack implements IAspect {
       line.push('N/A');
     }
     line.push(params.level);
-    return line.map((i) => '"' + i + '"').join(',') + '\n';
+    return line.map((i) => '"' + i.replace(/"/g, '""') + '"').join(',') + '\n';
   }
 }
 

--- a/src/nag-pack.ts
+++ b/src/nag-pack.ts
@@ -308,7 +308,7 @@ export abstract class NagPack implements IAspect {
       line.push('N/A');
     }
     line.push(params.level);
-    return line.join(',') + '\n';
+    return line.map((i) => '"' + i + '"').join(',') + '\n';
   }
 }
 

--- a/src/nag-pack.ts
+++ b/src/nag-pack.ts
@@ -274,7 +274,7 @@ export abstract class NagPack implements IAspect {
       this.reportStacks.push(fileName);
       writeFileSync(
         filePath,
-        'Rule ID,Resource ID,Compliance,Exception Reason,Rule Level\n'
+        'Rule ID,Resource ID,Compliance,Exception Reason,Rule Level,Rule Info\n'
       );
     }
     appendFileSync(filePath, line);
@@ -296,7 +296,7 @@ export abstract class NagPack implements IAspect {
       | 'UNKNOWN',
     explanation: string = ''
   ): string {
-    //| Rule ID | Resource ID | Compliance | Exception Reason | Rule Level
+    //| Rule ID | Resource ID | Compliance | Exception Reason | Rule Level | Rule Info
     const line = Array<string>();
     line.push(ruleId);
     line.push(params.node.node.path);
@@ -312,6 +312,7 @@ export abstract class NagPack implements IAspect {
       line.push('N/A');
     }
     line.push(params.level);
+    line.push(params.info);
     return line.map((i) => '"' + i.replace(/"/g, '""') + '"').join(',') + '\n';
   }
 }

--- a/src/nag-pack.ts
+++ b/src/nag-pack.ts
@@ -32,7 +32,7 @@ export interface NagPackProps {
   readonly logIgnores?: boolean;
 
   /**
-   * Whether or not to generate CSV compliance reports for applied Stacks in the App's output directory (default: false).
+   * Whether or not to generate CSV compliance reports for applied Stacks in the App's output directory (default: true).
    */
   readonly reports?: boolean;
 }
@@ -103,7 +103,7 @@ export abstract class NagPack implements IAspect {
         ? false
         : props.logIgnores;
     this.reports =
-      props == undefined || props.reports == undefined ? false : props.reports;
+      props == undefined || props.reports == undefined ? true : props.reports;
   }
 
   public get readPackName(): string {

--- a/src/rules/apigw/APIGWAccessLogging.ts
+++ b/src/rules/apigw/APIGWAccessLogging.ts
@@ -6,37 +6,40 @@ import { parse } from 'path';
 import { CfnStage } from '@aws-cdk/aws-apigateway';
 import { CfnStage as CfnV2Stage } from '@aws-cdk/aws-apigatewayv2';
 import { CfnResource, Stack } from '@aws-cdk/core';
-
+import { NagRuleCompliance } from '../../nag-pack';
 /**
  * APIs have access logging enabled
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnStage) {
       if (node.accessLogSetting == undefined) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
       const accessLogSetting = Stack.of(node).resolve(node.accessLogSetting);
       if (
         accessLogSetting.destinationArn == undefined ||
         accessLogSetting.format == undefined
       ) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
     } else if (node instanceof CfnV2Stage) {
       if (node.accessLogSettings == undefined) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
       const accessLogSetting = Stack.of(node).resolve(node.accessLogSettings);
       if (
         accessLogSetting.destinationArn == undefined ||
         accessLogSetting.format == undefined
       ) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/apigw/APIGWAssociatedWithWAF.ts
+++ b/src/rules/apigw/APIGWAssociatedWithWAF.ts
@@ -6,14 +6,17 @@ import { parse } from 'path';
 import { CfnStage } from '@aws-cdk/aws-apigateway';
 import { CfnWebACLAssociation } from '@aws-cdk/aws-wafv2';
 import { CfnResource, Stack } from '@aws-cdk/core';
-import { resolveResourceFromInstrinsic } from '../../nag-pack';
+import {
+  resolveResourceFromInstrinsic,
+  NagRuleCompliance,
+} from '../../nag-pack';
 
 /**
  * Rest API stages are associated with AWS WAFv2 web ACLs
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnStage) {
       const stageLogicalId = resolveResourceFromInstrinsic(node, node.ref);
       const stageName = resolveResourceFromInstrinsic(node, node.stageName);
@@ -35,10 +38,12 @@ export default Object.defineProperty(
         }
       }
       if (!found) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/apigw/APIGWAuthorization.ts
+++ b/src/rules/apigw/APIGWAuthorization.ts
@@ -6,14 +6,14 @@ import { parse } from 'path';
 import { AuthorizationType, CfnMethod } from '@aws-cdk/aws-apigateway';
 import { CfnRoute } from '@aws-cdk/aws-apigatewayv2';
 import { CfnResource } from '@aws-cdk/core';
-import { resolveIfPrimitive } from '../../nag-pack';
+import { resolveIfPrimitive, NagRuleCompliance } from '../../nag-pack';
 
 /**
  * APIs implement authorization
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnMethod || node instanceof CfnRoute) {
       const authorizationType = resolveIfPrimitive(
         node,
@@ -23,10 +23,12 @@ export default Object.defineProperty(
         authorizationType == undefined ||
         authorizationType == AuthorizationType.NONE
       ) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/apigw/APIGWCacheEnabledAndEncrypted.ts
+++ b/src/rules/apigw/APIGWCacheEnabledAndEncrypted.ts
@@ -5,16 +5,17 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnStage } from '@aws-cdk/aws-apigateway';
 import { CfnResource, Stack } from '@aws-cdk/core';
+import { NagRuleCompliance } from '../../nag-pack';
 
 /**
  * All methods in API Gateway stages have caching enabled and encrypted
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnStage) {
       if (node.methodSettings == undefined) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
       const methodSettings = Stack.of(node).resolve(node.methodSettings);
       let found = false;
@@ -31,10 +32,12 @@ export default Object.defineProperty(
         }
       }
       if (!found) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/apigw/APIGWExecutionLoggingEnabled.ts
+++ b/src/rules/apigw/APIGWExecutionLoggingEnabled.ts
@@ -5,16 +5,17 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnStage, MethodLoggingLevel } from '@aws-cdk/aws-apigateway';
 import { CfnResource, Stack } from '@aws-cdk/core';
+import { NagRuleCompliance } from '../../nag-pack';
 
 /**
  * API Gateway stages have logging enabled
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnStage) {
       if (node.methodSettings == undefined) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
       const methodSettings = Stack.of(node).resolve(node.methodSettings);
       let found = false;
@@ -31,10 +32,12 @@ export default Object.defineProperty(
         }
       }
       if (!found) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/apigw/APIGWRequestValidation.ts
+++ b/src/rules/apigw/APIGWRequestValidation.ts
@@ -5,14 +5,17 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnRequestValidator, CfnRestApi } from '@aws-cdk/aws-apigateway';
 import { CfnResource, Stack } from '@aws-cdk/core';
-import { resolveResourceFromInstrinsic } from '../../nag-pack';
+import {
+  resolveResourceFromInstrinsic,
+  NagRuleCompliance,
+} from '../../nag-pack';
 
 /**
  * Rest APIs have request validation enabled
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnRestApi) {
       const apiLogicalId = resolveResourceFromInstrinsic(node, node.ref);
       let found = false;
@@ -25,10 +28,12 @@ export default Object.defineProperty(
         }
       }
       if (!found) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/apigw/APIGWSSLEnabled.ts
+++ b/src/rules/apigw/APIGWSSLEnabled.ts
@@ -5,19 +5,22 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnStage } from '@aws-cdk/aws-apigateway';
 import { CfnResource } from '@aws-cdk/core';
+import { NagRuleCompliance } from '../../nag-pack';
 
 /**
  * API Gateway REST API stages are configured with SSL certificates
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnStage) {
       if (node.clientCertificateId == undefined) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/apigw/APIGWXrayEnabled.ts
+++ b/src/rules/apigw/APIGWXrayEnabled.ts
@@ -5,20 +5,22 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnStage } from '@aws-cdk/aws-apigateway';
 import { CfnResource } from '@aws-cdk/core';
-import { resolveIfPrimitive } from '../../nag-pack';
+import { resolveIfPrimitive, NagRuleCompliance } from '../../nag-pack';
 /**
  * API Gateway REST API stages have X-Ray tracing enabled
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnStage) {
       const tracingEnabled = resolveIfPrimitive(node, node.tracingEnabled);
       if (tracingEnabled !== true) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/appsync/AppSyncGraphQLRequestLogging.ts
+++ b/src/rules/appsync/AppSyncGraphQLRequestLogging.ts
@@ -5,18 +5,18 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnGraphQLApi } from '@aws-cdk/aws-appsync';
 import { CfnResource, Stack } from '@aws-cdk/core';
-import { resolveIfPrimitive } from '../../nag-pack';
+import { resolveIfPrimitive, NagRuleCompliance } from '../../nag-pack';
 
 /**
  * GraphQL APIs have request leveling logging enabled
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnGraphQLApi) {
       const logConfig = Stack.of(node).resolve(node.logConfig);
       if (logConfig === undefined) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
       const excludeVerboseContent = resolveIfPrimitive(
         node,
@@ -26,10 +26,12 @@ export default Object.defineProperty(
         logConfig.cloudWatchLogsRoleArn === undefined ||
         excludeVerboseContent === true
       ) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/athena/AthenaWorkgroupEncryptedQueryResults.ts
+++ b/src/rules/athena/AthenaWorkgroupEncryptedQueryResults.ts
@@ -5,14 +5,14 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnWorkGroup } from '@aws-cdk/aws-athena';
 import { CfnResource, Stack } from '@aws-cdk/core';
-import { resolveIfPrimitive } from '../../nag-pack';
+import { resolveIfPrimitive, NagRuleCompliance } from '../../nag-pack';
 
 /**
  * Athena workgroups encrypt query results
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnWorkGroup) {
       const workGroupConfiguration = Stack.of(node).resolve(
         node.workGroupConfiguration
@@ -22,7 +22,7 @@ export default Object.defineProperty(
           node.workGroupConfigurationUpdates
         );
         if (workGroupConfigurationUpdates == undefined) {
-          return false;
+          return NagRuleCompliance.NON_COMPLIANT;
         }
         const resultConfigurationUpdates = Stack.of(node).resolve(
           workGroupConfigurationUpdates.resultConfigurationUpdates
@@ -43,12 +43,12 @@ export default Object.defineProperty(
             removeEncryptionConfiguration &&
             encryptionConfiguration == undefined
           ) {
-            return false;
+            return NagRuleCompliance.NON_COMPLIANT;
           } else if (
             encryptionConfiguration != undefined &&
             !enforceWorkGroupConfiguration
           ) {
-            return false;
+            return NagRuleCompliance.NON_COMPLIANT;
           }
         }
       } else {
@@ -57,25 +57,27 @@ export default Object.defineProperty(
           workGroupConfiguration.enforceWorkGroupConfiguration
         );
         if (!enforceWorkGroupConfiguration) {
-          return false;
+          return NagRuleCompliance.NON_COMPLIANT;
         }
         const resultConfiguration = Stack.of(node).resolve(
           workGroupConfiguration.resultConfiguration
         );
 
         if (resultConfiguration == undefined) {
-          return false;
+          return NagRuleCompliance.NON_COMPLIANT;
         }
         const encryptionConfiguration = Stack.of(node).resolve(
           resultConfiguration.encryptionConfiguration
         );
 
         if (encryptionConfiguration == undefined) {
-          return false;
+          return NagRuleCompliance.NON_COMPLIANT;
         }
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/autoscaling/AutoScalingGroupCooldownPeriod.ts
+++ b/src/rules/autoscaling/AutoScalingGroupCooldownPeriod.ts
@@ -5,21 +5,23 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnAutoScalingGroup } from '@aws-cdk/aws-autoscaling';
 import { CfnResource } from '@aws-cdk/core';
-import { resolveIfPrimitive } from '../../nag-pack';
+import { resolveIfPrimitive, NagRuleCompliance } from '../../nag-pack';
 
 /**
  * Auto Scaling Groups have configured cooldown periods
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnAutoScalingGroup) {
       const cooldown = resolveIfPrimitive(node, node.cooldown);
       if (cooldown != undefined && parseInt(cooldown) == 0) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/autoscaling/AutoScalingGroupELBHealthCheckRequired.ts
+++ b/src/rules/autoscaling/AutoScalingGroupELBHealthCheckRequired.ts
@@ -5,13 +5,13 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnAutoScalingGroup } from '@aws-cdk/aws-autoscaling';
 import { CfnResource, Stack } from '@aws-cdk/core';
-import { resolveIfPrimitive } from '../../nag-pack';
+import { resolveIfPrimitive, NagRuleCompliance } from '../../nag-pack';
 /**
  * Auto Scaling groups which are associated with load balancers utilize ELB health checks
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnAutoScalingGroup) {
       const classicLBs = Stack.of(node).resolve(node.loadBalancerNames);
       const otherLBs = Stack.of(node).resolve(node.targetGroupArns);
@@ -22,14 +22,16 @@ export default Object.defineProperty(
         const healthCheckType = resolveIfPrimitive(node, node.healthCheckType);
         if (healthCheckType != undefined) {
           if (healthCheckType != 'ELB') {
-            return false;
+            return NagRuleCompliance.NON_COMPLIANT;
           }
         } else {
-          return false;
+          return NagRuleCompliance.NON_COMPLIANT;
         }
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/autoscaling/AutoScalingGroupHealthCheck.ts
+++ b/src/rules/autoscaling/AutoScalingGroupHealthCheck.ts
@@ -5,14 +5,14 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnAutoScalingGroup } from '@aws-cdk/aws-autoscaling';
 import { CfnResource } from '@aws-cdk/core';
-import { resolveIfPrimitive } from '../../nag-pack';
+import { resolveIfPrimitive, NagRuleCompliance } from '../../nag-pack';
 
 /**
  * Auto Scaling Groups have properly configured health checks
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnAutoScalingGroup) {
       const healthCheckType = resolveIfPrimitive(node, node.healthCheckType);
       const healthCheckGracePeriod = resolveIfPrimitive(
@@ -24,10 +24,12 @@ export default Object.defineProperty(
         healthCheckType == 'ELB' &&
         healthCheckGracePeriod == undefined
       ) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/autoscaling/AutoScalingLaunchConfigPublicIpDisabled.ts
+++ b/src/rules/autoscaling/AutoScalingLaunchConfigPublicIpDisabled.ts
@@ -5,23 +5,25 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnLaunchConfiguration } from '@aws-cdk/aws-autoscaling';
 import { CfnResource } from '@aws-cdk/core';
-import { resolveIfPrimitive } from '../../nag-pack';
+import { resolveIfPrimitive, NagRuleCompliance } from '../../nag-pack';
 /**
  * Auto Scaling launch configurations have public IP addresses disabled
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnLaunchConfiguration) {
       const associatePublicIpAddress = resolveIfPrimitive(
         node,
         node.associatePublicIpAddress
       );
       if (associatePublicIpAddress !== false) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/cloud9/Cloud9InstanceNoIngressSystemsManager.ts
+++ b/src/rules/cloud9/Cloud9InstanceNoIngressSystemsManager.ts
@@ -5,21 +5,23 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnEnvironmentEC2 } from '@aws-cdk/aws-cloud9';
 import { CfnResource } from '@aws-cdk/core';
-import { resolveIfPrimitive } from '../../nag-pack';
+import { resolveIfPrimitive, NagRuleCompliance } from '../../nag-pack';
 
 /**
  * Cloud9 instances use no-ingress EC2 instances with AWS Systems Manager
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnEnvironmentEC2) {
       const connectionType = resolveIfPrimitive(node, node.connectionType);
       if (connectionType == undefined || connectionType != 'CONNECT_SSM') {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/cloudfront/CloudFrontDistributionAccessLogging.ts
+++ b/src/rules/cloudfront/CloudFrontDistributionAccessLogging.ts
@@ -8,35 +8,38 @@ import {
   CfnStreamingDistribution,
 } from '@aws-cdk/aws-cloudfront';
 import { CfnResource, Stack } from '@aws-cdk/core';
-import { resolveIfPrimitive } from '../../nag-pack';
+import { resolveIfPrimitive, NagRuleCompliance } from '../../nag-pack';
 
 /**
  * CloudFront distributions have access logging enabled
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnDistribution) {
       const distributionConfig = Stack.of(node).resolve(
         node.distributionConfig
       );
       if (distributionConfig.logging == undefined) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
     } else if (node instanceof CfnStreamingDistribution) {
       const distributionConfig = Stack.of(node).resolve(
         node.streamingDistributionConfig
       );
       if (distributionConfig.logging == undefined) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
       const logging = Stack.of(node).resolve(distributionConfig.logging);
       const enabled = resolveIfPrimitive(node, logging.enabled);
       if (!enabled) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/cloudfront/CloudFrontDistributionGeoRestrictions.ts
+++ b/src/rules/cloudfront/CloudFrontDistributionGeoRestrictions.ts
@@ -5,20 +5,20 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnDistribution } from '@aws-cdk/aws-cloudfront';
 import { CfnResource, Stack } from '@aws-cdk/core';
-import { resolveIfPrimitive } from '../../nag-pack';
+import { resolveIfPrimitive, NagRuleCompliance } from '../../nag-pack';
 
 /**
  * CloudFront distributions may require Geo restrictions
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnDistribution) {
       const distributionConfig = Stack.of(node).resolve(
         node.distributionConfig
       );
       if (distributionConfig.restrictions == undefined) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       } else {
         const restrictions = Stack.of(node).resolve(
           distributionConfig.restrictions
@@ -31,11 +31,13 @@ export default Object.defineProperty(
           geoRestrictions.restrictionType
         );
         if (restrictionType == 'none') {
-          return false;
+          return NagRuleCompliance.NON_COMPLIANT;
         }
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/cloudfront/CloudFrontDistributionNoOutdatedSSL.ts
+++ b/src/rules/cloudfront/CloudFrontDistributionNoOutdatedSSL.ts
@@ -9,14 +9,14 @@ import {
   SecurityPolicyProtocol,
 } from '@aws-cdk/aws-cloudfront';
 import { CfnResource, Stack } from '@aws-cdk/core';
-import { resolveIfPrimitive } from '../../nag-pack';
+import { resolveIfPrimitive, NagRuleCompliance } from '../../nag-pack';
 
 /**
  * CloudFront distributions do not use SSLv3 or TLSv1 for communication to the origin
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnDistribution) {
       const distributionConfig = Stack.of(node).resolve(
         node.distributionConfig
@@ -34,10 +34,10 @@ export default Object.defineProperty(
               customOriginConfig.originProtocolPolicy
             );
             if (originProtocolPolicy != OriginProtocolPolicy.HTTPS_ONLY) {
-              return false;
+              return NagRuleCompliance.NON_COMPLIANT;
             }
             if (customOriginConfig.originSslProtocols == undefined) {
-              return false;
+              return NagRuleCompliance.NON_COMPLIANT;
             }
             const outdatedValues = [
               SecurityPolicyProtocol.SSL_V3,
@@ -51,14 +51,16 @@ export default Object.defineProperty(
             });
             for (const outdated of outdatedValues) {
               if (lowerCaseProtocols.includes(outdated.toLowerCase())) {
-                return false;
+                return NagRuleCompliance.NON_COMPLIANT;
               }
             }
           }
         }
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/cloudfront/CloudFrontDistributionWAFIntegration.ts
+++ b/src/rules/cloudfront/CloudFrontDistributionWAFIntegration.ts
@@ -5,22 +5,25 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnDistribution } from '@aws-cdk/aws-cloudfront';
 import { CfnResource, Stack } from '@aws-cdk/core';
+import { NagRuleCompliance } from '../../nag-pack';
 
 /**
  * CloudFront distributions may require integration with AWS WAF
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnDistribution) {
       const distributionConfig = Stack.of(node).resolve(
         node.distributionConfig
       );
       if (distributionConfig.webAclId == undefined) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/cloudtrail/CloudTrailCloudWatchLogsEnabled.ts
+++ b/src/rules/cloudtrail/CloudTrailCloudWatchLogsEnabled.ts
@@ -5,21 +5,24 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnTrail } from '@aws-cdk/aws-cloudtrail';
 import { CfnResource, Stack } from '@aws-cdk/core';
+import { NagRuleCompliance } from '../../nag-pack';
 
 /**
  * CloudTrail trails have CloudWatch logs enabled
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnTrail) {
       const cloudWatch = Stack.of(node).resolve(node.cloudWatchLogsLogGroupArn);
 
       if (cloudWatch == undefined) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/cloudtrail/CloudTrailEncryptionEnabled.ts
+++ b/src/rules/cloudtrail/CloudTrailEncryptionEnabled.ts
@@ -5,21 +5,24 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnTrail } from '@aws-cdk/aws-cloudtrail';
 import { CfnResource, Stack } from '@aws-cdk/core';
+import { NagRuleCompliance } from '../../nag-pack';
 
 /**
  * CloudTrail trails have encryption enabled
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnTrail) {
       const keyID = Stack.of(node).resolve(node.kmsKeyId);
 
       if (keyID == undefined) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/cloudtrail/CloudTrailLogFileValidationEnabled.ts
+++ b/src/rules/cloudtrail/CloudTrailLogFileValidationEnabled.ts
@@ -5,21 +5,23 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnTrail } from '@aws-cdk/aws-cloudtrail';
 import { CfnResource } from '@aws-cdk/core';
-import { resolveIfPrimitive } from '../../nag-pack';
+import { resolveIfPrimitive, NagRuleCompliance } from '../../nag-pack';
 /**
  * CloudTrail trails have log file validation enabled
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnTrail) {
       const enabled = resolveIfPrimitive(node, node.enableLogFileValidation);
 
       if (enabled != true) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/cloudwatch/CloudWatchAlarmAction.ts
+++ b/src/rules/cloudwatch/CloudWatchAlarmAction.ts
@@ -5,17 +5,18 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnAlarm } from '@aws-cdk/aws-cloudwatch';
 import { CfnResource, Stack } from '@aws-cdk/core';
+import { NagRuleCompliance } from '../../nag-pack';
 
 /**
  * CloudWatch alarms have at least one alarm action, one INSUFFICIENT_DATA action, or one OK action enabled
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnAlarm) {
       const actionsEnabled = Stack.of(node).resolve(node.actionsEnabled);
       if (actionsEnabled === false) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
       // Actions can be an array with a token that then resolves to an empty array or undefined
       const alarmActions = Stack.of(node).resolve(node.alarmActions);
@@ -31,10 +32,12 @@ export default Object.defineProperty(
       const totalActions =
         totalAlarmActions + totalInsufficientDataActions + totalOkActions;
       if (totalActions == 0) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/cloudwatch/CloudWatchLogGroupEncrypted.ts
+++ b/src/rules/cloudwatch/CloudWatchLogGroupEncrypted.ts
@@ -5,19 +5,22 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnLogGroup } from '@aws-cdk/aws-logs';
 import { CfnResource } from '@aws-cdk/core';
+import { NagRuleCompliance } from '../../nag-pack';
 
 /**
  * CloudWatch Log Groups are encrypted with customer managed keys
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnLogGroup) {
       if (node.kmsKeyId == undefined) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/cloudwatch/CloudWatchLogGroupRetentionPeriod.ts
+++ b/src/rules/cloudwatch/CloudWatchLogGroupRetentionPeriod.ts
@@ -5,19 +5,22 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnLogGroup } from '@aws-cdk/aws-logs';
 import { CfnResource } from '@aws-cdk/core';
+import { NagRuleCompliance } from '../../nag-pack';
 
 /**
  * CloudWatch Log Groups have an explicit retention period configured
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnLogGroup) {
       if (node.retentionInDays == undefined) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/codebuild/CodeBuildProjectEnvVarAwsCred.ts
+++ b/src/rules/codebuild/CodeBuildProjectEnvVarAwsCred.ts
@@ -5,14 +5,14 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnProject } from '@aws-cdk/aws-codebuild';
 import { CfnResource, Stack } from '@aws-cdk/core';
-import { resolveIfPrimitive } from '../../nag-pack';
+import { resolveIfPrimitive, NagRuleCompliance } from '../../nag-pack';
 
 /**
  * CodeBuild projects do not store AWS credentials as plaintext environment variables
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnProject) {
       //Check for the presence of OAUTH
       const environment = Stack.of(node).resolve(node.environment);
@@ -28,13 +28,15 @@ export default Object.defineProperty(
           if (name == 'AWS_ACCESS_KEY_ID' || name == 'AWS_SECRET_ACCESS_KEY') {
             //is this credential being stored as plaintext?
             if (type == undefined || type == 'PLAINTEXT') {
-              return false;
+              return NagRuleCompliance.NON_COMPLIANT;
             }
           }
         }
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/codebuild/CodeBuildProjectKMSEncryptedArtifacts.ts
+++ b/src/rules/codebuild/CodeBuildProjectKMSEncryptedArtifacts.ts
@@ -5,21 +5,23 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnProject } from '@aws-cdk/aws-codebuild';
 import { CfnResource } from '@aws-cdk/core';
-import { resolveIfPrimitive } from '../../nag-pack';
+import { resolveIfPrimitive, NagRuleCompliance } from '../../nag-pack';
 
 /**
  * Codebuild projects use an AWS KMS key for encryption
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnProject) {
       const encryptionKey = resolveIfPrimitive(node, node.encryptionKey);
       if (encryptionKey == undefined || encryptionKey == 'alias/aws/s3') {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/codebuild/CodeBuildProjectManagedImages.ts
+++ b/src/rules/codebuild/CodeBuildProjectManagedImages.ts
@@ -5,22 +5,24 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnProject } from '@aws-cdk/aws-codebuild';
 import { CfnResource, Stack } from '@aws-cdk/core';
-import { resolveIfPrimitive } from '../../nag-pack';
+import { resolveIfPrimitive, NagRuleCompliance } from '../../nag-pack';
 
 /**
  * Codebuild projects use images provided by the CodeBuild service or have a cdk_nag suppression rule explaining the need for a custom image
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnProject) {
       const environment = Stack.of(node).resolve(node.environment);
       const image = resolveIfPrimitive(node, environment.image);
       if (!image.startsWith('aws/codebuild/')) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/codebuild/CodeBuildProjectPrivilegedModeDisabled.ts
+++ b/src/rules/codebuild/CodeBuildProjectPrivilegedModeDisabled.ts
@@ -5,14 +5,14 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnProject } from '@aws-cdk/aws-codebuild';
 import { CfnResource, Stack } from '@aws-cdk/core';
-import { resolveIfPrimitive } from '../../nag-pack';
+import { resolveIfPrimitive, NagRuleCompliance } from '../../nag-pack';
 
 /**
  * Codebuild projects have privileged mode disabled
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnProject) {
       const environment = Stack.of(node).resolve(node.environment);
       const privilegedMode = resolveIfPrimitive(
@@ -20,10 +20,12 @@ export default Object.defineProperty(
         environment.privilegedMode
       );
       if (privilegedMode != undefined && privilegedMode) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/codebuild/CodeBuildProjectSourceRepoUrl.ts
+++ b/src/rules/codebuild/CodeBuildProjectSourceRepoUrl.ts
@@ -5,28 +5,30 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnProject } from '@aws-cdk/aws-codebuild';
 import { CfnResource, Stack } from '@aws-cdk/core';
-import { resolveIfPrimitive } from '../../nag-pack';
+import { resolveIfPrimitive, NagRuleCompliance } from '../../nag-pack';
 
 /**
  * Codebuild projects with a GitHub or BitBucket source repository utilize OAUTH
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnProject) {
       //Check for the presence of OAUTH
       const projectSource = Stack.of(node).resolve(node.source);
       const projectAuth = Stack.of(node).resolve(projectSource.auth);
       if (projectAuth == undefined) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       } else {
         const projectAuthType = resolveIfPrimitive(node, projectAuth.type);
         if (projectAuthType != 'OAUTH') {
-          return false;
+          return NagRuleCompliance.NON_COMPLIANT;
         }
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/cognito/CognitoUserPoolAPIGWAuthorizer.ts
+++ b/src/rules/cognito/CognitoUserPoolAPIGWAuthorizer.ts
@@ -5,19 +5,22 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnMethod } from '@aws-cdk/aws-apigateway';
 import { CfnResource } from '@aws-cdk/core';
+import { NagRuleCompliance } from '../../nag-pack';
 
 /**
  * Rest API methods use Cognito User Pool Authorizers
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnMethod) {
       if (node.authorizationType !== 'COGNITO_USER_POOLS') {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/cognito/CognitoUserPoolAdvancedSecurityModeEnforced.ts
+++ b/src/rules/cognito/CognitoUserPoolAdvancedSecurityModeEnforced.ts
@@ -5,18 +5,18 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnUserPool } from '@aws-cdk/aws-cognito';
 import { CfnResource, Stack } from '@aws-cdk/core';
-import { resolveIfPrimitive } from '../../nag-pack';
+import { resolveIfPrimitive, NagRuleCompliance } from '../../nag-pack';
 
 /**
  * Cognito user pools have AdvancedSecurityMode set to ENFORCED
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnUserPool) {
       const userPoolAddOns = Stack.of(node).resolve(node.userPoolAddOns);
       if (userPoolAddOns == undefined) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
       const advancedSecurityMode = resolveIfPrimitive(
         node,
@@ -26,10 +26,12 @@ export default Object.defineProperty(
         advancedSecurityMode == undefined ||
         advancedSecurityMode != 'ENFORCED'
       ) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/cognito/CognitoUserPoolMFA.ts
+++ b/src/rules/cognito/CognitoUserPoolMFA.ts
@@ -5,21 +5,23 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnUserPool, Mfa } from '@aws-cdk/aws-cognito';
 import { CfnResource } from '@aws-cdk/core';
-import { resolveIfPrimitive } from '../../nag-pack';
+import { resolveIfPrimitive, NagRuleCompliance } from '../../nag-pack';
 
 /**
  * Cognito user pools require MFA
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnUserPool) {
       const mfaConfiguration = resolveIfPrimitive(node, node.mfaConfiguration);
       if (mfaConfiguration == undefined || mfaConfiguration != Mfa.REQUIRED) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/cognito/CognitoUserPoolNoUnauthenticatedLogins.ts
+++ b/src/rules/cognito/CognitoUserPoolNoUnauthenticatedLogins.ts
@@ -5,24 +5,26 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnIdentityPool } from '@aws-cdk/aws-cognito';
 import { CfnResource } from '@aws-cdk/core';
-import { resolveIfPrimitive } from '../../nag-pack';
+import { resolveIfPrimitive, NagRuleCompliance } from '../../nag-pack';
 
 /**
  * Cognito identity pools do not allow for unauthenticated logins without a valid reason
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnIdentityPool) {
       const allowUnauthenticatedIdentities = resolveIfPrimitive(
         node,
         node.allowUnauthenticatedIdentities
       );
       if (allowUnauthenticatedIdentities) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/cognito/CognitoUserPoolStrongPasswordPolicy.ts
+++ b/src/rules/cognito/CognitoUserPoolStrongPasswordPolicy.ts
@@ -5,22 +5,22 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnUserPool } from '@aws-cdk/aws-cognito';
 import { CfnResource, Stack } from '@aws-cdk/core';
-import { resolveIfPrimitive } from '../../nag-pack';
+import { resolveIfPrimitive, NagRuleCompliance } from '../../nag-pack';
 
 /**
  * Cognito user pools have password policies that minimally specify a password length of at least 8 characters, as well as requiring uppercase, numeric, and special characters
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnUserPool) {
       const policies = Stack.of(node).resolve(node.policies);
       if (policies == undefined) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
       const passwordPolicy = Stack.of(node).resolve(policies.passwordPolicy);
       if (passwordPolicy == undefined) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
 
       const minimumLength = resolveIfPrimitive(
@@ -28,7 +28,7 @@ export default Object.defineProperty(
         passwordPolicy.minimumLength
       );
       if (minimumLength == undefined || minimumLength < 8) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
 
       const requireUppercase = resolveIfPrimitive(
@@ -36,7 +36,7 @@ export default Object.defineProperty(
         passwordPolicy.requireUppercase
       );
       if (requireUppercase !== true) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
 
       const requireNumbers = resolveIfPrimitive(
@@ -44,7 +44,7 @@ export default Object.defineProperty(
         passwordPolicy.requireNumbers
       );
       if (requireNumbers !== true) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
 
       const requireSymbols = resolveIfPrimitive(
@@ -52,10 +52,12 @@ export default Object.defineProperty(
         passwordPolicy.requireSymbols
       );
       if (requireSymbols !== true) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/dms/DMSReplicationNotPublic.ts
+++ b/src/rules/dms/DMSReplicationNotPublic.ts
@@ -5,21 +5,23 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnReplicationInstance } from '@aws-cdk/aws-dms';
 import { CfnResource } from '@aws-cdk/core';
-import { resolveIfPrimitive } from '../../nag-pack';
+import { resolveIfPrimitive, NagRuleCompliance } from '../../nag-pack';
 
 /**
  * DMS replication instances are not public
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnReplicationInstance) {
       const publicAccess = resolveIfPrimitive(node, node.publiclyAccessible);
       if (publicAccess !== false) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/documentdb/DocumentDBClusterBackupRetentionPeriod.ts
+++ b/src/rules/documentdb/DocumentDBClusterBackupRetentionPeriod.ts
@@ -5,24 +5,26 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnDBCluster } from '@aws-cdk/aws-docdb';
 import { CfnResource } from '@aws-cdk/core';
-import { resolveIfPrimitive } from '../../nag-pack';
+import { resolveIfPrimitive, NagRuleCompliance } from '../../nag-pack';
 
 /**
  * Document DB clusters have a reasonable minimum backup retention period configured
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnDBCluster) {
       const backupRetentionPeriod = resolveIfPrimitive(
         node,
         node.backupRetentionPeriod
       );
       if (backupRetentionPeriod == undefined || backupRetentionPeriod < 7) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/documentdb/DocumentDBClusterEncryptionAtRest.ts
+++ b/src/rules/documentdb/DocumentDBClusterEncryptionAtRest.ts
@@ -5,24 +5,26 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnDBCluster } from '@aws-cdk/aws-docdb';
 import { CfnResource } from '@aws-cdk/core';
-import { resolveIfPrimitive } from '../../nag-pack';
+import { resolveIfPrimitive, NagRuleCompliance } from '../../nag-pack';
 
 /**
  * Document DB clusters have encryption at rest enabled
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnDBCluster) {
       if (node.storageEncrypted == undefined) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
       const storageEncrypted = resolveIfPrimitive(node, node.storageEncrypted);
       if (!storageEncrypted) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/documentdb/DocumentDBClusterLogExports.ts
+++ b/src/rules/documentdb/DocumentDBClusterLogExports.ts
@@ -5,22 +5,28 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnDBCluster } from '@aws-cdk/aws-docdb';
 import { CfnResource } from '@aws-cdk/core';
+import { NagRuleCompliance } from '../../nag-pack';
 
 /**
  * Document DB clusters have authenticate, createIndex, and dropCollection Log Exports enabled
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnDBCluster) {
       if (node.enableCloudwatchLogsExports == undefined) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
       const needed = ['authenticate', 'createIndex', 'dropCollection'];
       const exports = node.enableCloudwatchLogsExports;
-      return needed.every((i) => exports.includes(i));
+      const compliant = needed.every((i) => exports.includes(i));
+      if (compliant !== true) {
+        return NagRuleCompliance.NON_COMPLIANT;
+      }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/documentdb/DocumentDBClusterNonDefaultPort.ts
+++ b/src/rules/documentdb/DocumentDBClusterNonDefaultPort.ts
@@ -5,21 +5,23 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnDBCluster } from '@aws-cdk/aws-docdb';
 import { CfnResource } from '@aws-cdk/core';
-import { resolveIfPrimitive } from '../../nag-pack';
+import { resolveIfPrimitive, NagRuleCompliance } from '../../nag-pack';
 
 /**
  * Document DB clusters do not use the default endpoint port
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnDBCluster) {
       const port = resolveIfPrimitive(node, node.port);
       if (port == undefined || port == 27017) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/documentdb/DocumentDBCredentialsInSecretsManager.ts
+++ b/src/rules/documentdb/DocumentDBCredentialsInSecretsManager.ts
@@ -5,14 +5,14 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnDBCluster } from '@aws-cdk/aws-docdb';
 import { CfnResource } from '@aws-cdk/core';
-import { resolveIfPrimitive } from '../../nag-pack';
+import { resolveIfPrimitive, NagRuleCompliance } from '../../nag-pack';
 
 /**
  * Document DB clusters have the username and password stored in Secrets Manager
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnDBCluster) {
       const masterUsername = resolveIfPrimitive(node, node.masterUsername);
       const masterUserPassword = resolveIfPrimitive(
@@ -23,10 +23,12 @@ export default Object.defineProperty(
         masterUsername.includes('{{resolve:secretsmanager') == false ||
         masterUserPassword.includes('{{resolve:secretsmanager') == false
       ) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/dynamodb/DAXEncrypted.ts
+++ b/src/rules/dynamodb/DAXEncrypted.ts
@@ -5,25 +5,27 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnCluster } from '@aws-cdk/aws-dax';
 import { CfnResource, Stack } from '@aws-cdk/core';
-import { resolveIfPrimitive } from '../../nag-pack';
+import { resolveIfPrimitive, NagRuleCompliance } from '../../nag-pack';
 
 /**
  * DAX clusters have server-side encryption enabled
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnCluster) {
       if (node.sseSpecification == undefined) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
       const sseSpecification = Stack.of(node).resolve(node.sseSpecification);
       const enabled = resolveIfPrimitive(node, sseSpecification.sseEnabled);
       if (!enabled) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/dynamodb/DynamoDBAutoScalingEnabled.ts
+++ b/src/rules/dynamodb/DynamoDBAutoScalingEnabled.ts
@@ -6,7 +6,10 @@ import { parse } from 'path';
 import { CfnScalableTarget } from '@aws-cdk/aws-applicationautoscaling';
 import { CfnTable, BillingMode } from '@aws-cdk/aws-dynamodb';
 import { CfnResource, Stack } from '@aws-cdk/core';
-import { resolveResourceFromInstrinsic } from '../../nag-pack';
+import {
+  resolveResourceFromInstrinsic,
+  NagRuleCompliance,
+} from '../../nag-pack';
 
 /**
  * Provisioned capacity DynamoDB tables have auto-scaling enabled on their indexes
@@ -14,7 +17,7 @@ import { resolveResourceFromInstrinsic } from '../../nag-pack';
  */
 
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnTable) {
       if (
         resolveResourceFromInstrinsic(node, node.billingMode) !==
@@ -60,11 +63,13 @@ export default Object.defineProperty(
           }
         }
         if (indexWriteMatches.length != 0 || indexReadMatches.length != 0) {
-          return false;
+          return NagRuleCompliance.NON_COMPLIANT;
         }
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/dynamodb/DynamoDBInBackupPlan.ts
+++ b/src/rules/dynamodb/DynamoDBInBackupPlan.ts
@@ -6,7 +6,10 @@ import { parse } from 'path';
 import { CfnBackupSelection } from '@aws-cdk/aws-backup';
 import { CfnTable } from '@aws-cdk/aws-dynamodb';
 import { CfnResource, Stack } from '@aws-cdk/core';
-import { resolveResourceFromInstrinsic } from '../../nag-pack';
+import {
+  resolveResourceFromInstrinsic,
+  NagRuleCompliance,
+} from '../../nag-pack';
 
 /**
  * DynamoDB tables are part of AWS Backup plan(s)
@@ -14,7 +17,7 @@ import { resolveResourceFromInstrinsic } from '../../nag-pack';
  */
 
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnTable) {
       const tableLogicalId = resolveResourceFromInstrinsic(node, node.ref);
       const tableName = Stack.of(node).resolve(node.tableName);
@@ -28,10 +31,12 @@ export default Object.defineProperty(
         }
       }
       if (!found) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/dynamodb/DynamoDBPITREnabled.ts
+++ b/src/rules/dynamodb/DynamoDBPITREnabled.ts
@@ -5,7 +5,7 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnTable } from '@aws-cdk/aws-dynamodb';
 import { CfnResource, Stack } from '@aws-cdk/core';
-import { resolveIfPrimitive } from '../../nag-pack';
+import { resolveIfPrimitive, NagRuleCompliance } from '../../nag-pack';
 
 /**
  * DynamoDB tables have Point-in-time Recovery enabled
@@ -13,20 +13,22 @@ import { resolveIfPrimitive } from '../../nag-pack';
  */
 
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnTable) {
       if (node.pointInTimeRecoverySpecification == undefined) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
       const pitr = Stack.of(node).resolve(
         node.pointInTimeRecoverySpecification
       );
       const enabled = resolveIfPrimitive(node, pitr.pointInTimeRecoveryEnabled);
       if (!enabled) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/ec2/EC2EBSInBackupPlan.ts
+++ b/src/rules/ec2/EC2EBSInBackupPlan.ts
@@ -6,7 +6,10 @@ import { parse } from 'path';
 import { CfnBackupSelection } from '@aws-cdk/aws-backup';
 import { CfnVolume } from '@aws-cdk/aws-ec2';
 import { CfnResource, Stack } from '@aws-cdk/core';
-import { resolveResourceFromInstrinsic } from '../../nag-pack';
+import {
+  resolveResourceFromInstrinsic,
+  NagRuleCompliance,
+} from '../../nag-pack';
 
 /**
  * EBS volumes are part of AWS Backup plan(s)
@@ -14,7 +17,7 @@ import { resolveResourceFromInstrinsic } from '../../nag-pack';
  */
 
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnVolume) {
       const volumeLogicalId = resolveResourceFromInstrinsic(node, node.ref);
       let found = false;
@@ -27,10 +30,12 @@ export default Object.defineProperty(
         }
       }
       if (!found) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/ec2/EC2EBSOptimizedInstance.ts
+++ b/src/rules/ec2/EC2EBSOptimizedInstance.ts
@@ -5,7 +5,7 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnInstance } from '@aws-cdk/aws-ec2';
 import { CfnResource, Stack } from '@aws-cdk/core';
-import { resolveIfPrimitive } from '../../nag-pack';
+import { resolveIfPrimitive, NagRuleCompliance } from '../../nag-pack';
 
 const EBS_OPTIMIZED_SUPPORTED = [
   'c1.xlarge',
@@ -33,7 +33,7 @@ const DEFAULT_TYPE = 'm1.small';
  *  @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnInstance) {
       const instanceType = node.instanceType
         ? resolveIfPrimitive(node, node.instanceType)
@@ -43,10 +43,12 @@ export default Object.defineProperty(
         EBS_OPTIMIZED_SUPPORTED.includes(instanceType) &&
         ebsOptimized !== true
       ) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/ec2/EC2EBSVolumeEncrypted.ts
+++ b/src/rules/ec2/EC2EBSVolumeEncrypted.ts
@@ -5,21 +5,23 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnVolume } from '@aws-cdk/aws-ec2';
 import { CfnResource } from '@aws-cdk/core';
-import { resolveIfPrimitive } from '../../nag-pack';
+import { resolveIfPrimitive, NagRuleCompliance } from '../../nag-pack';
 
 /**
  * EBS volumes have encryption enabled
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnVolume) {
       const encryption = resolveIfPrimitive(node, node.encrypted);
       if (encryption !== true) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/ec2/EC2InstanceDetailedMonitoringEnabled.ts
+++ b/src/rules/ec2/EC2InstanceDetailedMonitoringEnabled.ts
@@ -6,26 +6,29 @@ import { parse } from 'path';
 import { CfnLaunchConfiguration } from '@aws-cdk/aws-autoscaling';
 import { CfnInstance } from '@aws-cdk/aws-ec2';
 import { CfnResource } from '@aws-cdk/core';
-import { resolveIfPrimitive } from '../../nag-pack';
+import { resolveIfPrimitive, NagRuleCompliance } from '../../nag-pack';
 
 /**
  * EC2 instances have detailed monitoring enabled
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnInstance) {
       const monitoring = resolveIfPrimitive(node, node.monitoring);
       if (monitoring == undefined || monitoring == false) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
     } else if (node instanceof CfnLaunchConfiguration) {
       const monitoring = resolveIfPrimitive(node, node.instanceMonitoring);
       if (monitoring != undefined && monitoring == false) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/ec2/EC2InstanceNoPublicIp.ts
+++ b/src/rules/ec2/EC2InstanceNoPublicIp.ts
@@ -5,14 +5,14 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnInstance } from '@aws-cdk/aws-ec2';
 import { CfnResource, Stack } from '@aws-cdk/core';
-import { resolveIfPrimitive } from '../../nag-pack';
+import { resolveIfPrimitive, NagRuleCompliance } from '../../nag-pack';
 
 /**
  * EC2 instances do not have public IPs
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnInstance) {
       const networkInterfaces = Stack.of(node).resolve(node.networkInterfaces);
       if (networkInterfaces != undefined) {
@@ -24,12 +24,14 @@ export default Object.defineProperty(
             resolvedInterface.associatePublicIpAddress
           );
           if (associatePublicIpAddress === true) {
-            return false;
+            return NagRuleCompliance.NON_COMPLIANT;
           }
         }
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/ec2/EC2InstanceProfileAttached.ts
+++ b/src/rules/ec2/EC2InstanceProfileAttached.ts
@@ -5,19 +5,22 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnInstance } from '@aws-cdk/aws-ec2';
 import { CfnResource } from '@aws-cdk/core';
+import { NagRuleCompliance } from '../../nag-pack';
 
 /**
  * EC2 instances have an instance profile attached
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnInstance) {
       if (node.iamInstanceProfile == undefined) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/ec2/EC2InstanceTerminationProtection.ts
+++ b/src/rules/ec2/EC2InstanceTerminationProtection.ts
@@ -5,24 +5,26 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnInstance } from '@aws-cdk/aws-ec2';
 import { CfnResource } from '@aws-cdk/core';
-import { resolveIfPrimitive } from '../../nag-pack';
+import { resolveIfPrimitive, NagRuleCompliance } from '../../nag-pack';
 
 /**
  * EC2 Instances outside of an ASG have Termination Protection enabled
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnInstance) {
       const disableApiTermination = resolveIfPrimitive(
         node,
         node.disableApiTermination
       );
       if (disableApiTermination !== true) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/ec2/EC2InstancesInVPC.ts
+++ b/src/rules/ec2/EC2InstancesInVPC.ts
@@ -5,21 +5,24 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnInstance } from '@aws-cdk/aws-ec2';
 import { CfnResource, Stack } from '@aws-cdk/core';
+import { NagRuleCompliance } from '../../nag-pack';
 
 /**
  * EC2 instances are created within VPCs
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnInstance) {
       //If we are in a VPC, then we'll have a subnet
       const subnetId = Stack.of(node).resolve(node.subnetId);
       if (subnetId == undefined) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/ec2/EC2RestrictedInbound.ts
+++ b/src/rules/ec2/EC2RestrictedInbound.ts
@@ -5,14 +5,14 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnSecurityGroup, CfnSecurityGroupIngress } from '@aws-cdk/aws-ec2';
 import { CfnResource, Stack } from '@aws-cdk/core';
-import { resolveIfPrimitive } from '../../nag-pack';
+import { resolveIfPrimitive, NagRuleCompliance } from '../../nag-pack';
 
 /**
  * EC2 security groups do not allow for 0.0.0.0/0 or ::/0 inbound access
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnSecurityGroup) {
       const ingressRules = Stack.of(node).resolve(node.securityGroupIngress);
       if (ingressRules != undefined) {
@@ -24,27 +24,30 @@ export default Object.defineProperty(
             resolvedRule.cidrIpv6
           );
           if (resolvedcidrIp != undefined && resolvedcidrIp.includes('/0')) {
-            return false;
+            return NagRuleCompliance.NON_COMPLIANT;
           }
           if (
             resolvedcidrIpv6 != undefined &&
             resolvedcidrIpv6.includes('/0')
           ) {
-            return false;
+            return NagRuleCompliance.NON_COMPLIANT;
           }
         }
       }
+      return NagRuleCompliance.COMPLIANT;
     } else if (node instanceof CfnSecurityGroupIngress) {
       const resolvedcidrIp = resolveIfPrimitive(node, node.cidrIp);
       const resolvedcidrIpv6 = resolveIfPrimitive(node, node.cidrIpv6);
       if (resolvedcidrIp != undefined && resolvedcidrIp.includes('/0')) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
       if (resolvedcidrIpv6 != undefined && resolvedcidrIpv6.includes('/0')) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/ec2/EC2SecurityGroupDescription.ts
+++ b/src/rules/ec2/EC2SecurityGroupDescription.ts
@@ -5,21 +5,23 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnSecurityGroup } from '@aws-cdk/aws-ec2';
 import { CfnResource } from '@aws-cdk/core';
-import { resolveIfPrimitive } from '../../nag-pack';
+import { resolveIfPrimitive, NagRuleCompliance } from '../../nag-pack';
 
 /**
  * Security Groups have descriptions
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnSecurityGroup) {
       const description = resolveIfPrimitive(node, node.groupDescription);
       if (description.length < 2) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/ecr/ECROpenAccess.ts
+++ b/src/rules/ecr/ECROpenAccess.ts
@@ -5,21 +5,31 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnRegistryPolicy, CfnRepository } from '@aws-cdk/aws-ecr';
 import { CfnResource, Stack } from '@aws-cdk/core';
+import { NagRuleCompliance } from '../../nag-pack';
 
 /**
  * ECR Repositories do not allow open access
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnRegistryPolicy) {
       const policyText = Stack.of(node).resolve(node.policyText);
-      return checkStatement(policyText);
+      const compliant = checkStatement(policyText);
+      if (compliant !== true) {
+        return NagRuleCompliance.NON_COMPLIANT;
+      }
+      return NagRuleCompliance.COMPLIANT;
     } else if (node instanceof CfnRepository) {
       const policyText = Stack.of(node).resolve(node.repositoryPolicyText);
-      return checkStatement(policyText);
+      const compliant = checkStatement(policyText);
+      if (compliant !== true) {
+        return NagRuleCompliance.NON_COMPLIANT;
+      }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/ecs/ECSTaskDefinitionContainerLogging.ts
+++ b/src/rules/ecs/ECSTaskDefinitionContainerLogging.ts
@@ -5,21 +5,21 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnCluster } from '@aws-cdk/aws-ecs';
 import { CfnResource, Stack } from '@aws-cdk/core';
-import { resolveIfPrimitive } from '../../nag-pack';
+import { resolveIfPrimitive, NagRuleCompliance } from '../../nag-pack';
 
 /**
  * ECS Task Definition has awslogs logging enabled at the minimum
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnCluster) {
       if (node.configuration == undefined) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
       const configuration = Stack.of(node).resolve(node.configuration);
       if (configuration.executeCommandConfiguration == undefined) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
       const executeCommandConfiguration = resolveIfPrimitive(
         node,
@@ -29,10 +29,12 @@ export default Object.defineProperty(
         executeCommandConfiguration.logging == undefined ||
         executeCommandConfiguration.logging == 'NONE'
       ) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/efs/EFSEncrypted.ts
+++ b/src/rules/efs/EFSEncrypted.ts
@@ -5,21 +5,23 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnFileSystem } from '@aws-cdk/aws-efs';
 import { CfnResource } from '@aws-cdk/core';
-import { resolveIfPrimitive } from '../../nag-pack';
+import { resolveIfPrimitive, NagRuleCompliance } from '../../nag-pack';
 
 /**
  * Elastic File Systems are configured for encryption at rest
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnFileSystem) {
       const encrypted = resolveIfPrimitive(node, node.encrypted);
       if (encrypted === false) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/efs/EFSInBackupPlan.ts
+++ b/src/rules/efs/EFSInBackupPlan.ts
@@ -6,7 +6,10 @@ import { parse } from 'path';
 import { CfnBackupSelection } from '@aws-cdk/aws-backup';
 import { CfnFileSystem } from '@aws-cdk/aws-efs';
 import { CfnResource, Stack } from '@aws-cdk/core';
-import { resolveResourceFromInstrinsic } from '../../nag-pack';
+import {
+  resolveResourceFromInstrinsic,
+  NagRuleCompliance,
+} from '../../nag-pack';
 
 /**
  * EFSs are part of AWS Backup plan(s)
@@ -14,7 +17,7 @@ import { resolveResourceFromInstrinsic } from '../../nag-pack';
  */
 
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnFileSystem) {
       const fileSystemLogicalId = resolveResourceFromInstrinsic(node, node.ref);
       let found = false;
@@ -27,10 +30,12 @@ export default Object.defineProperty(
         }
       }
       if (!found) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/elasticache/ElastiCacheClusterInVPC.ts
+++ b/src/rules/elasticache/ElastiCacheClusterInVPC.ts
@@ -5,13 +5,14 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnCacheCluster, CfnReplicationGroup } from '@aws-cdk/aws-elasticache';
 import { CfnResource } from '@aws-cdk/core';
+import { NagRuleCompliance } from '../../nag-pack';
 
 /**
  * ElastiCache clusters are provisioned in a VPC
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (
       node instanceof CfnCacheCluster ||
       node instanceof CfnReplicationGroup
@@ -20,10 +21,12 @@ export default Object.defineProperty(
         node.cacheSubnetGroupName == undefined ||
         node.cacheSubnetGroupName.length == 0
       ) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/elasticache/ElastiCacheClusterNonDefaultPort.ts
+++ b/src/rules/elasticache/ElastiCacheClusterNonDefaultPort.ts
@@ -5,39 +5,42 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnReplicationGroup, CfnCacheCluster } from '@aws-cdk/aws-elasticache';
 import { CfnResource } from '@aws-cdk/core';
-import { resolveIfPrimitive } from '../../nag-pack';
+import { resolveIfPrimitive, NagRuleCompliance } from '../../nag-pack';
 
 /**
  * ElastiCache clusters do not use the default endpoint ports
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnCacheCluster) {
       const port = resolveIfPrimitive(node, node.port);
       if (port == undefined) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
       const engine = resolveIfPrimitive(node, node.engine);
       if (engine.toLowerCase() == 'redis' && port == 6379) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       } else if (engine.toLowerCase() == 'memcached' && port == 11211) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
     } else if (node instanceof CfnReplicationGroup) {
       const port = resolveIfPrimitive(node, node.port);
       if (port == undefined) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
       const engine = resolveIfPrimitive(node, node.engine);
       if (
         (engine == undefined || engine.toLowerCase() == 'redis') &&
         port == 6379
       ) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/elasticache/ElastiCacheRedisClusterAutomaticBackup.ts
+++ b/src/rules/elasticache/ElastiCacheRedisClusterAutomaticBackup.ts
@@ -5,27 +5,30 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnCacheCluster, CfnReplicationGroup } from '@aws-cdk/aws-elasticache';
 import { CfnResource } from '@aws-cdk/core';
-import { resolveIfPrimitive } from '../../nag-pack';
+import { resolveIfPrimitive, NagRuleCompliance } from '../../nag-pack';
 
 /**
  * ElastiCache Redis clusters retain automatic backups for at least 15 days
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnCacheCluster) {
       const engine = resolveIfPrimitive(node, node.engine.toLowerCase());
       const retention = resolveIfPrimitive(node, node.snapshotRetentionLimit);
       if (engine == 'redis' && (retention == undefined || retention < 15)) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
     } else if (node instanceof CfnReplicationGroup) {
       const retention = resolveIfPrimitive(node, node.snapshotRetentionLimit);
       if (retention == undefined || retention < 15) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/elasticache/ElastiCacheRedisClusterEncryption.ts
+++ b/src/rules/elasticache/ElastiCacheRedisClusterEncryption.ts
@@ -5,29 +5,30 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnReplicationGroup } from '@aws-cdk/aws-elasticache';
 import { CfnResource } from '@aws-cdk/core';
-import { resolveIfPrimitive } from '../../nag-pack';
+import { resolveIfPrimitive, NagRuleCompliance } from '../../nag-pack';
 
 /**
  * ElastiCache Redis clusters have both encryption in transit and at rest enabled
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnReplicationGroup) {
       if (
         node.atRestEncryptionEnabled == undefined ||
         node.transitEncryptionEnabled == undefined
       ) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
       const rest = resolveIfPrimitive(node, node.atRestEncryptionEnabled);
       const transit = resolveIfPrimitive(node, node.transitEncryptionEnabled);
       if (rest == false || transit == false) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/elasticache/ElastiCacheRedisClusterMultiAZ.ts
+++ b/src/rules/elasticache/ElastiCacheRedisClusterMultiAZ.ts
@@ -5,24 +5,26 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnReplicationGroup } from '@aws-cdk/aws-elasticache';
 import { CfnResource } from '@aws-cdk/core';
-import { resolveIfPrimitive } from '../../nag-pack';
+import { resolveIfPrimitive, NagRuleCompliance } from '../../nag-pack';
 
 /**
  * ElastiCache Redis clusters are deployed in a Multi-AZ configuration
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnReplicationGroup) {
       if (node.multiAzEnabled == undefined) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
       const multiAz = resolveIfPrimitive(node, node.multiAzEnabled);
       if (!multiAz) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/elasticache/ElastiCacheRedisClusterRedisAuth.ts
+++ b/src/rules/elasticache/ElastiCacheRedisClusterRedisAuth.ts
@@ -5,19 +5,22 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnReplicationGroup } from '@aws-cdk/aws-elasticache';
 import { CfnResource } from '@aws-cdk/core';
+import { NagRuleCompliance } from '../../nag-pack';
 
 /**
  * ElastiCache Redis clusters use Redis AUTH for user authentication
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnReplicationGroup) {
       if (node.authToken == undefined || node.authToken.length == 0) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/elasticbeanstalk/ElasticBeanstalkEC2InstanceLogsToS3.ts
+++ b/src/rules/elasticbeanstalk/ElasticBeanstalkEC2InstanceLogsToS3.ts
@@ -5,6 +5,7 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnEnvironment } from '@aws-cdk/aws-elasticbeanstalk';
 import { CfnResource, Stack } from '@aws-cdk/core';
+import { NagRuleCompliance } from '../../nag-pack';
 
 /**
  * EC2 instances in Elastic Beanstalk environments upload rotated logs to S3
@@ -12,11 +13,11 @@ import { CfnResource, Stack } from '@aws-cdk/core';
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnEnvironment) {
       const optionSettings = Stack.of(node).resolve(node.optionSettings);
       if (optionSettings == undefined) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
       let foundEnabled = false;
       for (const optionSetting of optionSettings) {
@@ -34,10 +35,12 @@ export default Object.defineProperty(
         }
       }
       if (!foundEnabled) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/elasticbeanstalk/ElasticBeanstalkEnhancedHealthReportingEnabled.ts
+++ b/src/rules/elasticbeanstalk/ElasticBeanstalkEnhancedHealthReportingEnabled.ts
@@ -5,17 +5,18 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnEnvironment } from '@aws-cdk/aws-elasticbeanstalk';
 import { CfnResource, Stack } from '@aws-cdk/core';
+import { NagRuleCompliance } from '../../nag-pack';
 
 /**
  * Elastic Beanstalk environments have enhanced health reporting enabled
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnEnvironment) {
       const optionSettings = Stack.of(node).resolve(node.optionSettings);
       if (optionSettings == undefined) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
       let found = false;
       for (const optionSetting of optionSettings) {
@@ -33,10 +34,12 @@ export default Object.defineProperty(
         }
       }
       if (!found) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/elasticbeanstalk/ElasticBeanstalkManagedUpdatesEnabled.ts
+++ b/src/rules/elasticbeanstalk/ElasticBeanstalkManagedUpdatesEnabled.ts
@@ -5,6 +5,7 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnEnvironment } from '@aws-cdk/aws-elasticbeanstalk';
 import { CfnResource, Stack } from '@aws-cdk/core';
+import { NagRuleCompliance } from '../../nag-pack';
 
 /**
  * Elastic Beanstalk environments have managed updates enabled
@@ -12,11 +13,11 @@ import { CfnResource, Stack } from '@aws-cdk/core';
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnEnvironment) {
       const optionSettings = Stack.of(node).resolve(node.optionSettings);
       if (optionSettings == undefined) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
       let foundEnabled = false;
       let foundLevel = false;
@@ -46,10 +47,12 @@ export default Object.defineProperty(
         }
       }
       if (!foundEnabled || !foundLevel) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/elasticbeanstalk/ElasticBeanstalkVPCSpecified.ts
+++ b/src/rules/elasticbeanstalk/ElasticBeanstalkVPCSpecified.ts
@@ -5,6 +5,7 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnEnvironment } from '@aws-cdk/aws-elasticbeanstalk';
 import { CfnResource, Stack } from '@aws-cdk/core';
+import { NagRuleCompliance } from '../../nag-pack';
 
 /**
  * Elastic Beanstalk environments are configured to use a specific VPC
@@ -12,11 +13,11 @@ import { CfnResource, Stack } from '@aws-cdk/core';
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnEnvironment) {
       const optionSettings = Stack.of(node).resolve(node.optionSettings);
       if (optionSettings == undefined) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
       let foundEnabled = false;
       for (const optionSetting of optionSettings) {
@@ -34,10 +35,12 @@ export default Object.defineProperty(
         }
       }
       if (!foundEnabled) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/elb/ALBHttpDropInvalidHeaderEnabled.ts
+++ b/src/rules/elb/ALBHttpDropInvalidHeaderEnabled.ts
@@ -5,14 +5,14 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnLoadBalancer } from '@aws-cdk/aws-elasticloadbalancingv2';
 import { CfnResource, Stack } from '@aws-cdk/core';
-import { resolveIfPrimitive } from '../../nag-pack';
+import { resolveIfPrimitive, NagRuleCompliance } from '../../nag-pack';
 
 /**
  * Application Load Balancers are enabled to drop invalid headers
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnLoadBalancer) {
       const type = resolveIfPrimitive(node, node.type);
       if (type == undefined || type == 'application') {
@@ -21,14 +21,16 @@ export default Object.defineProperty(
           const reg =
             /"routing\.http\.drop_invalid_header_fields\.enabled","value":"true"/gm;
           if (JSON.stringify(attributes).search(reg) == -1) {
-            return false;
+            return NagRuleCompliance.NON_COMPLIANT;
           }
         } else {
-          return false;
+          return NagRuleCompliance.NON_COMPLIANT;
         }
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/elb/ALBHttpToHttpsRedirection.ts
+++ b/src/rules/elb/ALBHttpToHttpsRedirection.ts
@@ -5,14 +5,14 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnListener } from '@aws-cdk/aws-elasticloadbalancingv2';
 import { CfnResource, Stack } from '@aws-cdk/core';
-import { resolveIfPrimitive } from '../../nag-pack';
+import { resolveIfPrimitive, NagRuleCompliance } from '../../nag-pack';
 
 /**
  * ALB HTTP listeners are configured to redirect to HTTPS
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnListener) {
       let found = false;
       const protocol = resolveIfPrimitive(node, node.protocol);
@@ -27,11 +27,12 @@ export default Object.defineProperty(
             found = true;
           }
         }
-        if (!found) return false;
+        if (!found) return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/elb/ALBWAFEnabled.ts
+++ b/src/rules/elb/ALBWAFEnabled.ts
@@ -9,6 +9,7 @@ import { CfnResource, Stack } from '@aws-cdk/core';
 import {
   resolveIfPrimitive,
   resolveResourceFromInstrinsic,
+  NagRuleCompliance,
 } from '../../nag-pack';
 
 /**
@@ -17,7 +18,7 @@ import {
  */
 
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnLoadBalancer) {
       const type = resolveIfPrimitive(node, node.type);
       if (type === undefined || type === 'application') {
@@ -35,11 +36,13 @@ export default Object.defineProperty(
           }
         }
         if (!found) {
-          return false;
+          return NagRuleCompliance.NON_COMPLIANT;
         }
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/elb/CLBConnectionDraining.ts
+++ b/src/rules/elb/CLBConnectionDraining.ts
@@ -5,26 +5,28 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnLoadBalancer } from '@aws-cdk/aws-elasticloadbalancing';
 import { CfnResource, Stack } from '@aws-cdk/core';
-import { resolveIfPrimitive } from '../../nag-pack';
+import { resolveIfPrimitive, NagRuleCompliance } from '../../nag-pack';
 
 /**
  * CLBs have connection draining enabled.
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnLoadBalancer) {
       if (node.connectionDrainingPolicy == undefined) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
       const draining = Stack.of(node).resolve(node.connectionDrainingPolicy);
       const resolvedDraining = Stack.of(node).resolve(draining);
       const enabled = resolveIfPrimitive(node, resolvedDraining.enabled);
       if (enabled !== true) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/elb/CLBNoInboundHttpHttps.ts
+++ b/src/rules/elb/CLBNoInboundHttpHttps.ts
@@ -5,14 +5,14 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnLoadBalancer } from '@aws-cdk/aws-elasticloadbalancing';
 import { CfnResource, Stack } from '@aws-cdk/core';
-import { resolveIfPrimitive } from '../../nag-pack';
+import { resolveIfPrimitive, NagRuleCompliance } from '../../nag-pack';
 
 /**
  * CLBs are not used for incoming HTTP/HTTPS traffic. Use ALBs instead.
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnLoadBalancer) {
       const listeners = Stack.of(node).resolve(node.listeners);
       for (const listener of listeners) {
@@ -22,11 +22,13 @@ export default Object.defineProperty(
           protocol.toLowerCase() == 'http' ||
           protocol.toLowerCase() == 'https'
         ) {
-          return false;
+          return NagRuleCompliance.NON_COMPLIANT;
         }
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/elb/ELBACMCertificateRequired.ts
+++ b/src/rules/elb/ELBACMCertificateRequired.ts
@@ -5,14 +5,14 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnLoadBalancer } from '@aws-cdk/aws-elasticloadbalancing';
 import { CfnResource, Stack } from '@aws-cdk/core';
-import { resolveIfPrimitive } from '../../nag-pack';
+import { resolveIfPrimitive, NagRuleCompliance } from '../../nag-pack';
 
 /**
  * CLBs use ACM-managed certificates
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnLoadBalancer) {
       //For each listener, ensure that it's utilizing an ACM SSL/HTTPS cert
       const listeners = Stack.of(node).resolve(node.listeners);
@@ -26,17 +26,19 @@ export default Object.defineProperty(
           );
           //Use the ARN to check if this is an ACM managed cert
           if (listenerARN == undefined) {
-            return false;
+            return NagRuleCompliance.NON_COMPLIANT;
           } else {
             const acmRegex = /^arn:[^:]+:acm:.+$/;
             if (!acmRegex.test(listenerARN)) {
-              return false;
+              return NagRuleCompliance.NON_COMPLIANT;
             }
           }
         }
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/elb/ELBCrossZoneLoadBalancingEnabled.ts
+++ b/src/rules/elb/ELBCrossZoneLoadBalancingEnabled.ts
@@ -5,34 +5,36 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnLoadBalancer } from '@aws-cdk/aws-elasticloadbalancing';
 import { CfnResource } from '@aws-cdk/core';
-import { resolveIfPrimitive } from '../../nag-pack';
+import { resolveIfPrimitive, NagRuleCompliance } from '../../nag-pack';
 
 /**
  * CLBs use at least two AZs with the Cross-Zone Load Balancing feature enabled
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnLoadBalancer) {
       if (node.crossZone == undefined) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
       if (node.subnets == undefined) {
         if (
           node.availabilityZones == undefined ||
           node.availabilityZones.length < 2
         ) {
-          return false;
+          return NagRuleCompliance.NON_COMPLIANT;
         }
       } else if (node.subnets.length < 2) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
       const crossZone = resolveIfPrimitive(node, node.crossZone);
       if (crossZone != true) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/elb/ELBDeletionProtectionEnabled.ts
+++ b/src/rules/elb/ELBDeletionProtectionEnabled.ts
@@ -5,13 +5,14 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnLoadBalancer } from '@aws-cdk/aws-elasticloadbalancingv2';
 import { CfnResource, Stack } from '@aws-cdk/core';
+import { NagRuleCompliance } from '../../nag-pack';
 
 /**
  * ALBs, NLBs, and GLBs have deletion protection enabled
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnLoadBalancer) {
       const attributes = Stack.of(node).resolve(node.loadBalancerAttributes);
       if (attributes != undefined) {
@@ -28,13 +29,15 @@ export default Object.defineProperty(
           }
         }
         if (!deletionProtectionEnabled) {
-          return false;
+          return NagRuleCompliance.NON_COMPLIANT;
         }
       } else {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/elb/ELBLoggingEnabled.ts
+++ b/src/rules/elb/ELBLoggingEnabled.ts
@@ -6,17 +6,17 @@ import { parse } from 'path';
 import { CfnLoadBalancer } from '@aws-cdk/aws-elasticloadbalancing';
 import { CfnLoadBalancer as CfnLoadBalancerV2 } from '@aws-cdk/aws-elasticloadbalancingv2';
 import { CfnResource, Stack } from '@aws-cdk/core';
-import { resolveIfPrimitive } from '../../nag-pack';
+import { resolveIfPrimitive, NagRuleCompliance } from '../../nag-pack';
 
 /**
  * ELBs have access logs enabled
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnLoadBalancer) {
       if (node.accessLoggingPolicy == undefined) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
       const accessLoggingPolicy = Stack.of(node).resolve(
         node.accessLoggingPolicy
@@ -24,17 +24,20 @@ export default Object.defineProperty(
       const enabled = resolveIfPrimitive(node, accessLoggingPolicy.enabled);
 
       if (enabled == false) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
     } else if (node instanceof CfnLoadBalancerV2) {
       const attributes = Stack.of(node).resolve(node.loadBalancerAttributes);
       const reg = /"access_logs\.s3\.enabled","value":"true"/gm;
 
       if (JSON.stringify(attributes).search(reg) == -1) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/elb/ELBTlsHttpsListenersOnly.ts
+++ b/src/rules/elb/ELBTlsHttpsListenersOnly.ts
@@ -5,14 +5,14 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnLoadBalancer } from '@aws-cdk/aws-elasticloadbalancing';
 import { CfnResource, Stack } from '@aws-cdk/core';
-import { resolveIfPrimitive } from '../../nag-pack';
+import { resolveIfPrimitive, NagRuleCompliance } from '../../nag-pack';
 
 /**
  * CLB listeners are configured for secure (HTTPs or SSL) protocols for client communication
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnLoadBalancer) {
       const listeners = Stack.of(node).resolve(node.listeners);
       for (const listener of listeners) {
@@ -29,7 +29,7 @@ export default Object.defineProperty(
               instanceProtocol.toLowerCase() == 'ssl'
             )
           ) {
-            return false;
+            return NagRuleCompliance.NON_COMPLIANT;
           }
         } else if (protocol.toLowerCase() == 'https') {
           if (
@@ -38,12 +38,14 @@ export default Object.defineProperty(
               instanceProtocol.toLowerCase() == 'https'
             )
           ) {
-            return false;
+            return NagRuleCompliance.NON_COMPLIANT;
           }
         }
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/elb/ELBv2ACMCertificateRequired.ts
+++ b/src/rules/elb/ELBv2ACMCertificateRequired.ts
@@ -5,17 +5,18 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnListener } from '@aws-cdk/aws-elasticloadbalancingv2';
 import { CfnResource, Stack } from '@aws-cdk/core';
+import { NagRuleCompliance } from '../../nag-pack';
 
 /**
  * ALB, NLB, and GLB listeners use ACM-managed certificates
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnListener) {
       const certificates = Stack.of(node).resolve(node.certificates);
       if (certificates == undefined) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
       let found = false;
       for (const certificate of certificates) {
@@ -26,10 +27,12 @@ export default Object.defineProperty(
         }
       }
       if (!found) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/emr/EMRAuthEC2KeyPairOrKerberos.ts
+++ b/src/rules/emr/EMRAuthEC2KeyPairOrKerberos.ts
@@ -5,13 +5,14 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnCluster } from '@aws-cdk/aws-emr';
 import { CfnResource, Stack } from '@aws-cdk/core';
+import { NagRuleCompliance } from '../../nag-pack';
 
 /**
  * EMR clusters implement authentication via an EC2 Key Pair or Kerberos
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnCluster) {
       const kerberosAttributes = Stack.of(node).resolve(
         node.kerberosAttributes
@@ -19,11 +20,13 @@ export default Object.defineProperty(
       if (kerberosAttributes == undefined) {
         const instanceConfig = Stack.of(node).resolve(node.instances);
         if (instanceConfig.ec2KeyName == undefined) {
-          return false;
+          return NagRuleCompliance.NON_COMPLIANT;
         }
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/emr/EMRKerberosEnabled.ts
+++ b/src/rules/emr/EMRKerberosEnabled.ts
@@ -5,22 +5,25 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnCluster } from '@aws-cdk/aws-emr';
 import { CfnResource, Stack } from '@aws-cdk/core';
+import { NagRuleCompliance } from '../../nag-pack';
 
 /**
  * EMR clusters have Kerberos enabled
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnCluster) {
       const kerberosAttributes = Stack.of(node).resolve(
         node.kerberosAttributes
       );
       if (kerberosAttributes == undefined) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/emr/EMRS3AccessLogging.ts
+++ b/src/rules/emr/EMRS3AccessLogging.ts
@@ -5,20 +5,23 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnCluster } from '@aws-cdk/aws-emr';
 import { CfnResource, Stack } from '@aws-cdk/core';
+import { NagRuleCompliance } from '../../nag-pack';
 
 /**
  * EMR clusters have S3 logging enabled
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnCluster) {
       const logUri = Stack.of(node).resolve(node.logUri);
       if (logUri == undefined) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/iam/IAMGroupHasUsers.ts
+++ b/src/rules/iam/IAMGroupHasUsers.ts
@@ -5,7 +5,10 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnGroup, CfnUser, CfnUserToGroupAddition } from '@aws-cdk/aws-iam';
 import { CfnResource, Stack } from '@aws-cdk/core';
-import { resolveResourceFromInstrinsic } from '../../nag-pack';
+import {
+  resolveResourceFromInstrinsic,
+  NagRuleCompliance,
+} from '../../nag-pack';
 
 /**
  * IAM Groups have at least one IAM User
@@ -13,7 +16,7 @@ import { resolveResourceFromInstrinsic } from '../../nag-pack';
  */
 
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnGroup) {
       const groupLogicalId = resolveResourceFromInstrinsic(node, node.ref);
       const groupName = Stack.of(node).resolve(node.groupName);
@@ -32,10 +35,12 @@ export default Object.defineProperty(
         }
       }
       if (!found) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/iam/IAMNoInlinePolicy.ts
+++ b/src/rules/iam/IAMNoInlinePolicy.ts
@@ -5,13 +5,14 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnRole, CfnUser, CfnGroup, CfnPolicy } from '@aws-cdk/aws-iam';
 import { CfnResource, Stack } from '@aws-cdk/core';
+import { NagRuleCompliance } from '../../nag-pack';
 
 /**
  * IAM Groups, Users, and Roles do not contain inline policies
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (
       node instanceof CfnGroup ||
       node instanceof CfnUser ||
@@ -19,13 +20,14 @@ export default Object.defineProperty(
     ) {
       const inlinePolicies = Stack.of(node).resolve(node.policies);
       if (inlinePolicies != undefined) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else if (node instanceof CfnPolicy) {
+      return NagRuleCompliance.NON_COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    if (node instanceof CfnPolicy) {
-      return false;
-    }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/iam/IAMNoManagedPolicies.ts
+++ b/src/rules/iam/IAMNoManagedPolicies.ts
@@ -5,13 +5,14 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnRole, CfnUser, CfnGroup } from '@aws-cdk/aws-iam';
 import { CfnResource, Stack } from '@aws-cdk/core';
+import { NagRuleCompliance } from '../../nag-pack';
 
 /**
  * IAM users, roles, and groups do not use AWS managed policies
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (
       node instanceof CfnGroup ||
       node instanceof CfnUser ||
@@ -25,12 +26,14 @@ export default Object.defineProperty(
           if (
             !(/\d{12}/.test(arnPrefix) || arnPrefix.includes('AWS::AccountId'))
           ) {
-            return false;
+            return NagRuleCompliance.NON_COMPLIANT;
           }
         }
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/iam/IAMNoWildcardPermissions.ts
+++ b/src/rules/iam/IAMNoWildcardPermissions.ts
@@ -11,13 +11,14 @@ import {
   CfnManagedPolicy,
 } from '@aws-cdk/aws-iam';
 import { CfnResource, Stack } from '@aws-cdk/core';
+import { NagRuleCompliance } from '../../nag-pack';
 
 /**
  * IAM entities with wildcard permissions have a cdk_nag rule suppression with evidence for those permission
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (
       node instanceof CfnGroup ||
       node instanceof CfnUser ||
@@ -31,17 +32,20 @@ export default Object.defineProperty(
             resolvedPolicy.policyDocument
           );
           if (JSON.stringify(resolvedPolicyDocument).includes('*')) {
-            return false;
+            return NagRuleCompliance.NON_COMPLIANT;
           }
         }
       }
+      return NagRuleCompliance.COMPLIANT;
     } else if (node instanceof CfnPolicy || node instanceof CfnManagedPolicy) {
       const policyDocument = Stack.of(node).resolve(node.policyDocument);
       if (JSON.stringify(policyDocument).includes('*')) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/iam/IAMPolicyNoStatementsWithAdminAccess.ts
+++ b/src/rules/iam/IAMPolicyNoStatementsWithAdminAccess.ts
@@ -11,23 +11,27 @@ import {
   CfnRole,
 } from '@aws-cdk/aws-iam';
 import { CfnResource, Stack } from '@aws-cdk/core';
+import { NagRuleCompliance } from '../../nag-pack';
 
 /**
  * IAM policies do not grant admin access
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnPolicy || node instanceof CfnManagedPolicy) {
       if (checkDocument(node, node.policyDocument)) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
     } else if (node instanceof CfnGroup || node instanceof CfnRole) {
       if (node.policies != undefined && checkDocument(node, node.policies)) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/iam/IAMPolicyNoStatementsWithFullAccess.ts
+++ b/src/rules/iam/IAMPolicyNoStatementsWithFullAccess.ts
@@ -11,23 +11,27 @@ import {
   CfnRole,
 } from '@aws-cdk/aws-iam';
 import { CfnResource, Stack } from '@aws-cdk/core';
+import { NagRuleCompliance } from '../../nag-pack';
 
 /**
  * IAM policies do not grant full access
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnPolicy || node instanceof CfnManagedPolicy) {
       if (checkDocument(node, node.policyDocument)) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
     } else if (node instanceof CfnGroup || node instanceof CfnRole) {
       if (node.policies != undefined && checkDocument(node, node.policies)) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/iam/IAMUserGroupMembership.ts
+++ b/src/rules/iam/IAMUserGroupMembership.ts
@@ -5,20 +5,23 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnUser } from '@aws-cdk/aws-iam';
 import { CfnResource, Stack } from '@aws-cdk/core';
+import { NagRuleCompliance } from '../../nag-pack';
 
 /**
  * IAM users are assigned to at least one group
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnUser) {
       const userGroup = Stack.of(node).resolve(node.groups);
       if (userGroup == undefined) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/iam/IAMUserNoPolicies.ts
+++ b/src/rules/iam/IAMUserNoPolicies.ts
@@ -5,25 +5,29 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnPolicy, CfnManagedPolicy, CfnUser } from '@aws-cdk/aws-iam';
 import { CfnResource, Stack } from '@aws-cdk/core';
+import { NagRuleCompliance } from '../../nag-pack';
 /**
  * IAM policies are not attached at the user level
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnPolicy || node instanceof CfnManagedPolicy) {
       const policyUsers = Stack.of(node).resolve(node.users);
       if (policyUsers != undefined) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
     } else if (node instanceof CfnUser) {
       const policies = Stack.of(node).resolve(node.policies);
       const managedPolicyArns = Stack.of(node).resolve(node.managedPolicyArns);
       if (policies != undefined || managedPolicyArns != undefined) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/kinesis/KinesisDataAnalyticsFlinkCheckpointing.ts
+++ b/src/rules/kinesis/KinesisDataAnalyticsFlinkCheckpointing.ts
@@ -5,33 +5,33 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnApplicationV2 } from '@aws-cdk/aws-kinesisanalytics';
 import { CfnResource, Stack } from '@aws-cdk/core';
-import { resolveIfPrimitive } from '../../nag-pack';
+import { resolveIfPrimitive, NagRuleCompliance } from '../../nag-pack';
 
 /**
  * Kinesis Data Analytics Flink Applications have checkpointing enabled
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnApplicationV2) {
       if (node.runtimeEnvironment.toLowerCase().startsWith('flink')) {
         const applicationConfiguration = Stack.of(node).resolve(
           node.applicationConfiguration
         );
         if (applicationConfiguration == undefined) {
-          return false;
+          return NagRuleCompliance.NON_COMPLIANT;
         }
         const flinkApplicationConfiguration = Stack.of(node).resolve(
           applicationConfiguration.flinkApplicationConfiguration
         );
         if (flinkApplicationConfiguration == undefined) {
-          return false;
+          return NagRuleCompliance.NON_COMPLIANT;
         }
         const checkpointConfiguration = Stack.of(node).resolve(
           flinkApplicationConfiguration.checkpointConfiguration
         );
         if (checkpointConfiguration == undefined) {
-          return false;
+          return NagRuleCompliance.NON_COMPLIANT;
         }
         if (
           resolveIfPrimitive(node, checkpointConfiguration.configurationType) ==
@@ -42,12 +42,14 @@ export default Object.defineProperty(
             checkpointConfiguration.checkpointingEnabled
           );
           if (!enabled) {
-            return false;
+            return NagRuleCompliance.NON_COMPLIANT;
           }
         }
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/kinesis/KinesisDataFirehoseSSE.ts
+++ b/src/rules/kinesis/KinesisDataFirehoseSSE.ts
@@ -5,22 +5,25 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnDeliveryStream } from '@aws-cdk/aws-kinesisfirehose';
 import { CfnResource, Stack } from '@aws-cdk/core';
+import { NagRuleCompliance } from '../../nag-pack';
 
 /**
  * Kinesis Data Firehose delivery stream have server-side encryption enabled
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnDeliveryStream) {
       const deliveryStreamEncryptionConfigurationInput = Stack.of(node).resolve(
         node.deliveryStreamEncryptionConfigurationInput
       );
       if (deliveryStreamEncryptionConfigurationInput == undefined) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/kinesis/KinesisDataStreamDefaultKeyWhenSSE.ts
+++ b/src/rules/kinesis/KinesisDataStreamDefaultKeyWhenSSE.ts
@@ -5,22 +5,25 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnStream } from '@aws-cdk/aws-kinesis';
 import { CfnResource, Stack } from '@aws-cdk/core';
+import { NagRuleCompliance } from '../../nag-pack';
 
 /**
  * Kinesis Data Streams use the "aws/kinesis" key when server-sided encryption is enabled
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnStream) {
       const streamEncryption = Stack.of(node).resolve(node.streamEncryption);
       if (streamEncryption !== undefined) {
         if (streamEncryption.keyId !== 'alias/aws/kinesis') {
-          return false;
+          return NagRuleCompliance.NON_COMPLIANT;
         }
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/kinesis/KinesisDataStreamSSE.ts
+++ b/src/rules/kinesis/KinesisDataStreamSSE.ts
@@ -5,20 +5,23 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnStream } from '@aws-cdk/aws-kinesis';
 import { CfnResource, Stack } from '@aws-cdk/core';
+import { NagRuleCompliance } from '../../nag-pack';
 
 /**
  * Kinesis Data Streams have server-side encryption enabled
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnStream) {
       const streamEncryption = Stack.of(node).resolve(node.streamEncryption);
       if (streamEncryption == undefined) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/kms/KMSBackingKeyRotationEnabled.ts
+++ b/src/rules/kms/KMSBackingKeyRotationEnabled.ts
@@ -5,14 +5,14 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnKey, KeySpec } from '@aws-cdk/aws-kms';
 import { CfnResource, Stack } from '@aws-cdk/core';
-import { resolveIfPrimitive } from '../../nag-pack';
+import { resolveIfPrimitive, NagRuleCompliance } from '../../nag-pack';
 
 /**
  * KMS Symmetric keys have automatic key rotation enabled
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnKey) {
       const keySpec = Stack.of(node).resolve(node.keySpec);
       if (keySpec == undefined || keySpec == KeySpec.SYMMETRIC_DEFAULT) {
@@ -21,11 +21,13 @@ export default Object.defineProperty(
           node.enableKeyRotation
         );
         if (enableKeyRotation !== true) {
-          return false;
+          return NagRuleCompliance.NON_COMPLIANT;
         }
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/lambda/LambdaConcurrency.ts
+++ b/src/rules/lambda/LambdaConcurrency.ts
@@ -5,14 +5,14 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnFunction } from '@aws-cdk/aws-lambda';
 import { CfnResource } from '@aws-cdk/core';
-import { resolveIfPrimitive } from '../../nag-pack';
+import { resolveIfPrimitive, NagRuleCompliance } from '../../nag-pack';
 
 /**
  * Lambda functions are configured with function-level concurrent execution limits
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnFunction) {
       const reservedConcurrentExecutions = resolveIfPrimitive(
         node,
@@ -22,10 +22,12 @@ export default Object.defineProperty(
         reservedConcurrentExecutions == undefined ||
         reservedConcurrentExecutions === 0
       ) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/lambda/LambdaDLQ.ts
+++ b/src/rules/lambda/LambdaDLQ.ts
@@ -5,23 +5,26 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnFunction } from '@aws-cdk/aws-lambda';
 import { CfnResource, Stack } from '@aws-cdk/core';
+import { NagRuleCompliance } from '../../nag-pack';
 
 /**
  * Lambda functions are configured with a dead-letter configuration
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnFunction) {
       const deadLetterConfig = Stack.of(node).resolve(node.deadLetterConfig);
       if (
         deadLetterConfig == undefined ||
         deadLetterConfig.targetArn == undefined
       ) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/lambda/LambdaInsideVPC.ts
+++ b/src/rules/lambda/LambdaInsideVPC.ts
@@ -5,28 +5,31 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnFunction } from '@aws-cdk/aws-lambda';
 import { CfnResource, Stack } from '@aws-cdk/core';
+import { NagRuleCompliance } from '../../nag-pack';
 
 /**
  * Lambda functions are VPC enabled
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnFunction) {
       const vpcConfig = Stack.of(node).resolve(node.vpcConfig);
       if (vpcConfig == undefined) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       } else {
         const secgroups = Stack.of(node).resolve(vpcConfig.securityGroupIds);
         const subnets = Stack.of(node).resolve(vpcConfig.subnetIds);
         if (secgroups == undefined || secgroups.length == 0) {
           if (subnets == undefined || subnets.length == 0) {
-            return false;
+            return NagRuleCompliance.NON_COMPLIANT;
           }
         }
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/mediastore/MediaStoreCloudWatchMetricPolicy.ts
+++ b/src/rules/mediastore/MediaStoreCloudWatchMetricPolicy.ts
@@ -5,28 +5,30 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnContainer } from '@aws-cdk/aws-mediastore';
 import { CfnResource, Stack } from '@aws-cdk/core';
-import { resolveIfPrimitive } from '../../nag-pack';
+import { resolveIfPrimitive, NagRuleCompliance } from '../../nag-pack';
 
 /**
  * Media Store containers define metric policies to send metrics to CloudWatch
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnContainer) {
       const metricPolicy = Stack.of(node).resolve(node.metricPolicy);
       if (metricPolicy == undefined) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
       const containerLevelMetrics = resolveIfPrimitive(
         node,
         metricPolicy.containerLevelMetrics
       );
       if (containerLevelMetrics != 'ENABLED') {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/mediastore/MediaStoreContainerAccessLogging.ts
+++ b/src/rules/mediastore/MediaStoreContainerAccessLogging.ts
@@ -5,24 +5,26 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnContainer } from '@aws-cdk/aws-mediastore';
 import { CfnResource } from '@aws-cdk/core';
-import { resolveIfPrimitive } from '../../nag-pack';
+import { resolveIfPrimitive, NagRuleCompliance } from '../../nag-pack';
 
 /**
  * Media Store containers have container access logging enabled
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnContainer) {
       const accessLoggingEnabled = resolveIfPrimitive(
         node,
         node.accessLoggingEnabled
       );
       if (accessLoggingEnabled !== true) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/mediastore/MediaStoreContainerCORSPolicy.ts
+++ b/src/rules/mediastore/MediaStoreContainerCORSPolicy.ts
@@ -5,20 +5,23 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnContainer } from '@aws-cdk/aws-mediastore';
 import { CfnResource, Stack } from '@aws-cdk/core';
+import { NagRuleCompliance } from '../../nag-pack';
 
 /**
  * Media Store containers define CORS policies
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnContainer) {
       const corsPolicy = Stack.of(node).resolve(node.corsPolicy);
       if (corsPolicy == undefined || corsPolicy.length == 0) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/mediastore/MediaStoreContainerHasContainerPolicy.ts
+++ b/src/rules/mediastore/MediaStoreContainerHasContainerPolicy.ts
@@ -5,20 +5,23 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnContainer } from '@aws-cdk/aws-mediastore';
 import { CfnResource, Stack } from '@aws-cdk/core';
+import { NagRuleCompliance } from '../../nag-pack';
 
 /**
  * Media Store containers define container policies
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnContainer) {
       const policy = Stack.of(node).resolve(node.policy);
       if (policy == undefined) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/mediastore/MediaStoreContainerLifecyclePolicy.ts
+++ b/src/rules/mediastore/MediaStoreContainerLifecyclePolicy.ts
@@ -5,20 +5,23 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnContainer } from '@aws-cdk/aws-mediastore';
 import { CfnResource, Stack } from '@aws-cdk/core';
+import { NagRuleCompliance } from '../../nag-pack';
 
 /**
  * Media Store containers define lifecycle policies
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnContainer) {
       const lifecyclePolicy = Stack.of(node).resolve(node.lifecyclePolicy);
       if (lifecyclePolicy == undefined) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/msk/MSKBrokerLogging.ts
+++ b/src/rules/msk/MSKBrokerLogging.ts
@@ -5,18 +5,18 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnCluster } from '@aws-cdk/aws-msk';
 import { CfnResource, Stack } from '@aws-cdk/core';
-import { resolveIfPrimitive } from '../../nag-pack';
+import { resolveIfPrimitive, NagRuleCompliance } from '../../nag-pack';
 
 /**
  * MSK clusters send broker logs to a supported destination
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnCluster) {
       const loggingInfo = Stack.of(node).resolve(node.loggingInfo);
       if (loggingInfo == undefined) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
       const resolvedBrokerLogs = Stack.of(node).resolve(loggingInfo.brokerLogs);
       let enabled = false;
@@ -47,10 +47,12 @@ export default Object.defineProperty(
         }
       }
       if (!enabled) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/msk/MSKBrokerToBrokerTLS.ts
+++ b/src/rules/msk/MSKBrokerToBrokerTLS.ts
@@ -5,14 +5,14 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnCluster } from '@aws-cdk/aws-msk';
 import { CfnResource, Stack } from '@aws-cdk/core';
-import { resolveIfPrimitive } from '../../nag-pack';
+import { resolveIfPrimitive, NagRuleCompliance } from '../../nag-pack';
 
 /**
  * MSK clusters use TLS communication between brokers
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnCluster) {
       const encryptionInfo = Stack.of(node).resolve(node.encryptionInfo);
       if (encryptionInfo != undefined) {
@@ -25,12 +25,14 @@ export default Object.defineProperty(
             encryptionInTransit.inCluster
           );
           if (inCluster === false) {
-            return false;
+            return NagRuleCompliance.NON_COMPLIANT;
           }
         }
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/msk/MSKClientToBrokerTLS.ts
+++ b/src/rules/msk/MSKClientToBrokerTLS.ts
@@ -5,14 +5,14 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnCluster, ClientBrokerEncryption } from '@aws-cdk/aws-msk';
 import { CfnResource, Stack } from '@aws-cdk/core';
-import { resolveIfPrimitive } from '../../nag-pack';
+import { resolveIfPrimitive, NagRuleCompliance } from '../../nag-pack';
 
 /**
  * MSK clusters only uses TLS communication between clients and brokers
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnCluster) {
       const encryptionInfo = Stack.of(node).resolve(node.encryptionInfo);
       if (encryptionInfo != undefined) {
@@ -28,12 +28,14 @@ export default Object.defineProperty(
             clientBroker != undefined &&
             clientBroker != ClientBrokerEncryption.TLS
           ) {
-            return false;
+            return NagRuleCompliance.NON_COMPLIANT;
           }
         }
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/msk/MSKClientToBrokerTLS.ts
+++ b/src/rules/msk/MSKClientToBrokerTLS.ts
@@ -3,7 +3,7 @@ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 import { parse } from 'path';
-import { CfnCluster, ClientBrokerEncryption } from '@aws-cdk/aws-msk';
+import { CfnCluster } from '@aws-cdk/aws-msk';
 import { CfnResource, Stack } from '@aws-cdk/core';
 import { resolveIfPrimitive, NagRuleCompliance } from '../../nag-pack';
 
@@ -24,10 +24,7 @@ export default Object.defineProperty(
             node,
             encryptionInTransit.clientBroker
           );
-          if (
-            clientBroker != undefined &&
-            clientBroker != ClientBrokerEncryption.TLS
-          ) {
+          if (clientBroker != undefined && clientBroker != 'TLS') {
             return NagRuleCompliance.NON_COMPLIANT;
           }
         }

--- a/src/rules/neptune/NeptuneClusterAutomaticMinorVersionUpgrade.ts
+++ b/src/rules/neptune/NeptuneClusterAutomaticMinorVersionUpgrade.ts
@@ -5,27 +5,29 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnDBInstance } from '@aws-cdk/aws-neptune';
 import { CfnResource } from '@aws-cdk/core';
-import { resolveIfPrimitive } from '../../nag-pack';
+import { resolveIfPrimitive, NagRuleCompliance } from '../../nag-pack';
 
 /**
  * Neptune DB instances have Auto Minor Version Upgrade enabled
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnDBInstance) {
       if (node.autoMinorVersionUpgrade == undefined) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
       const autoMinorVersionUpgrade = resolveIfPrimitive(
         node,
         node.autoMinorVersionUpgrade
       );
       if (!autoMinorVersionUpgrade) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/neptune/NeptuneClusterBackupRetentionPeriod.ts
+++ b/src/rules/neptune/NeptuneClusterBackupRetentionPeriod.ts
@@ -5,24 +5,26 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnDBCluster } from '@aws-cdk/aws-neptune';
 import { CfnResource } from '@aws-cdk/core';
-import { resolveIfPrimitive } from '../../nag-pack';
+import { resolveIfPrimitive, NagRuleCompliance } from '../../nag-pack';
 
 /**
  * Neptune DB clusters have a reasonable minimum backup retention period configured
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnDBCluster) {
       const backupRetentionPeriod = resolveIfPrimitive(
         node,
         node.backupRetentionPeriod
       );
       if (backupRetentionPeriod == undefined || backupRetentionPeriod < 7) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/neptune/NeptuneClusterEncryptionAtRest.ts
+++ b/src/rules/neptune/NeptuneClusterEncryptionAtRest.ts
@@ -5,24 +5,26 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnDBCluster } from '@aws-cdk/aws-neptune';
 import { CfnResource } from '@aws-cdk/core';
-import { resolveIfPrimitive } from '../../nag-pack';
+import { resolveIfPrimitive, NagRuleCompliance } from '../../nag-pack';
 
 /**
  * Neptune DB clusters have encryption at rest enabled
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnDBCluster) {
       if (node.storageEncrypted == undefined) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
       const storageEncrypted = resolveIfPrimitive(node, node.storageEncrypted);
       if (!storageEncrypted) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/neptune/NeptuneClusterIAMAuth.ts
+++ b/src/rules/neptune/NeptuneClusterIAMAuth.ts
@@ -5,24 +5,26 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnDBCluster } from '@aws-cdk/aws-neptune';
 import { CfnResource } from '@aws-cdk/core';
-import { resolveIfPrimitive } from '../../nag-pack';
+import { resolveIfPrimitive, NagRuleCompliance } from '../../nag-pack';
 
 /**
  * Neptune DB clusters have IAM Database Authentication enabled
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnDBCluster) {
       if (node.iamAuthEnabled == undefined) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
       const iamAuthEnabled = resolveIfPrimitive(node, node.iamAuthEnabled);
       if (!iamAuthEnabled) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/neptune/NeptuneClusterMultiAZ.ts
+++ b/src/rules/neptune/NeptuneClusterMultiAZ.ts
@@ -5,25 +5,28 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnDBCluster } from '@aws-cdk/aws-neptune';
 import { CfnResource } from '@aws-cdk/core';
+import { NagRuleCompliance } from '../../nag-pack';
 
 /**
  * Neptune DB clusters are deployed in a Multi-AZ configuration
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnDBCluster) {
       if (node.dbSubnetGroupName == undefined) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
       if (
         node.availabilityZones != undefined &&
         node.availabilityZones.length < 2
       ) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/opensearch/OpenSearchAllowlistedIPs.ts
+++ b/src/rules/opensearch/OpenSearchAllowlistedIPs.ts
@@ -6,32 +6,35 @@ import { parse } from 'path';
 import { CfnDomain as LegacyCfnDomain } from '@aws-cdk/aws-elasticsearch';
 import { CfnDomain } from '@aws-cdk/aws-opensearchservice';
 import { CfnResource, Stack } from '@aws-cdk/core';
+import { NagRuleCompliance } from '../../nag-pack';
 
 /**
  * OpenSearch Service domains only grant access via allowlisted IP addresses
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof LegacyCfnDomain || node instanceof CfnDomain) {
       const accessPolicies = Stack.of(node).resolve(node.accessPolicies);
       if (accessPolicies === undefined) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
       const statements = accessPolicies?.Statement;
       if (statements === undefined || statements.length === 0) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
       for (const statement of statements) {
         if (statement.Effect === 'Allow') {
           const allowList = statement?.Condition?.IpAddress?.['aws:sourceIp'];
           if (allowList === undefined || allowList.length === 0) {
-            return false;
+            return NagRuleCompliance.NON_COMPLIANT;
           }
         }
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/opensearch/OpenSearchDedicatedMasterNode.ts
+++ b/src/rules/opensearch/OpenSearchDedicatedMasterNode.ts
@@ -6,42 +6,45 @@ import { parse } from 'path';
 import { CfnDomain as LegacyCfnDomain } from '@aws-cdk/aws-elasticsearch';
 import { CfnDomain } from '@aws-cdk/aws-opensearchservice';
 import { CfnResource, Stack } from '@aws-cdk/core';
-import { resolveIfPrimitive } from '../../nag-pack';
+import { resolveIfPrimitive, NagRuleCompliance } from '../../nag-pack';
 
 /**
  * OpenSearch Service domains use dedicated master nodes
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof LegacyCfnDomain) {
       const elasticsearchClusterConfig = Stack.of(node).resolve(
         node.elasticsearchClusterConfig
       );
       if (elasticsearchClusterConfig == undefined) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
       const dedicatedMasterEnabled = resolveIfPrimitive(
         node,
         elasticsearchClusterConfig.dedicatedMasterEnabled
       );
       if (!dedicatedMasterEnabled) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
     } else if (node instanceof CfnDomain) {
       const clusterConfig = Stack.of(node).resolve(node.clusterConfig);
       if (clusterConfig == undefined) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
       const dedicatedMasterEnabled = resolveIfPrimitive(
         node,
         clusterConfig.dedicatedMasterEnabled
       );
       if (!dedicatedMasterEnabled) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/opensearch/OpenSearchEncryptedAtRest.ts
+++ b/src/rules/opensearch/OpenSearchEncryptedAtRest.ts
@@ -6,14 +6,14 @@ import { parse } from 'path';
 import { CfnDomain as LegacyCfnDomain } from '@aws-cdk/aws-elasticsearch';
 import { CfnDomain } from '@aws-cdk/aws-opensearchservice';
 import { CfnResource, Stack } from '@aws-cdk/core';
-import { resolveIfPrimitive } from '../../nag-pack';
+import { resolveIfPrimitive, NagRuleCompliance } from '../../nag-pack';
 
 /**
  * OpenSearch Service domains have encryption at rest enabled
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof LegacyCfnDomain || node instanceof CfnDomain) {
       const encryptionAtRestOptions = Stack.of(node).resolve(
         node.encryptionAtRestOptions
@@ -24,13 +24,15 @@ export default Object.defineProperty(
           encryptionAtRestOptions.enabled
         );
         if (enabled !== true) {
-          return false;
+          return NagRuleCompliance.NON_COMPLIANT;
         }
       } else {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/opensearch/OpenSearchErrorLogsToCloudWatch.ts
+++ b/src/rules/opensearch/OpenSearchErrorLogsToCloudWatch.ts
@@ -6,28 +6,31 @@ import { parse } from 'path';
 import { CfnDomain as LegacyCfnDomain } from '@aws-cdk/aws-elasticsearch';
 import { CfnDomain } from '@aws-cdk/aws-opensearchservice';
 import { CfnResource, Stack } from '@aws-cdk/core';
+import { NagRuleCompliance } from '../../nag-pack';
 
 /**
  * OpenSearch Service domains stream error logs to CloudWatch Logs
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof LegacyCfnDomain || node instanceof CfnDomain) {
       const logPublishingOptions = Stack.of(node).resolve(
         node.logPublishingOptions
       );
       if (logPublishingOptions === undefined) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
       const resolvedLog = Stack.of(node).resolve(
         logPublishingOptions?.ES_APPLICATION_LOGS
       );
       if (resolvedLog === undefined) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/opensearch/OpenSearchInVPCOnly.ts
+++ b/src/rules/opensearch/OpenSearchInVPCOnly.ts
@@ -6,24 +6,27 @@ import { parse } from 'path';
 import { CfnDomain as LegacyCfnDomain } from '@aws-cdk/aws-elasticsearch';
 import { CfnDomain } from '@aws-cdk/aws-opensearchservice';
 import { CfnResource, Stack } from '@aws-cdk/core';
+import { NagRuleCompliance } from '../../nag-pack';
 
 /**
  * OpenSearch Service domains are within VPCs
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof LegacyCfnDomain || node instanceof CfnDomain) {
       const vpcOptions = Stack.of(node).resolve(node.vpcOptions);
       if (vpcOptions === undefined) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
       const subnetIds = Stack.of(node).resolve(vpcOptions.subnetIds);
       if (subnetIds === undefined || subnetIds.length === 0) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/opensearch/OpenSearchNodeToNodeEncryption.ts
+++ b/src/rules/opensearch/OpenSearchNodeToNodeEncryption.ts
@@ -6,14 +6,14 @@ import { parse } from 'path';
 import { CfnDomain as LegacyCfnDomain } from '@aws-cdk/aws-elasticsearch';
 import { CfnDomain } from '@aws-cdk/aws-opensearchservice';
 import { CfnResource, Stack } from '@aws-cdk/core';
-import { resolveIfPrimitive } from '../../nag-pack';
+import { resolveIfPrimitive, NagRuleCompliance } from '../../nag-pack';
 
 /**
  * OpenSearch Service domains are node-to-node encrypted
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof LegacyCfnDomain || node instanceof CfnDomain) {
       const encryptedNodeToNode = Stack.of(node).resolve(
         node.nodeToNodeEncryptionOptions
@@ -21,13 +21,15 @@ export default Object.defineProperty(
       if (encryptedNodeToNode != undefined) {
         const enabled = resolveIfPrimitive(node, encryptedNodeToNode.enabled);
         if (enabled !== true) {
-          return false;
+          return NagRuleCompliance.NON_COMPLIANT;
         }
       } else {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/opensearch/OpenSearchSlowLogsToCloudWatch.ts
+++ b/src/rules/opensearch/OpenSearchSlowLogsToCloudWatch.ts
@@ -6,20 +6,20 @@ import { parse } from 'path';
 import { CfnDomain as LegacyCfnDomain } from '@aws-cdk/aws-elasticsearch';
 import { CfnDomain } from '@aws-cdk/aws-opensearchservice';
 import { CfnResource, Stack } from '@aws-cdk/core';
-import { resolveIfPrimitive } from '../../nag-pack';
+import { resolveIfPrimitive, NagRuleCompliance } from '../../nag-pack';
 
 /**
  * OpenSearch Service domains minimally publish SEARCH_SLOW_LOGS and INDEX_SLOW_LOGS to CloudWatch Logs
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof LegacyCfnDomain || node instanceof CfnDomain) {
       const logPublishingOptions = Stack.of(node).resolve(
         node.logPublishingOptions
       );
       if (logPublishingOptions == undefined) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
       const requiredSlowLogs = [
         logPublishingOptions?.SEARCH_SLOW_LOGS,
@@ -28,15 +28,17 @@ export default Object.defineProperty(
       for (const log of requiredSlowLogs) {
         const resolvedLog = Stack.of(node).resolve(log);
         if (resolvedLog == undefined) {
-          return false;
+          return NagRuleCompliance.NON_COMPLIANT;
         }
         const enabled = resolveIfPrimitive(node, resolvedLog.enabled);
         if (!enabled) {
-          return false;
+          return NagRuleCompliance.NON_COMPLIANT;
         }
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/opensearch/OpenSearchZoneAwareness.ts
+++ b/src/rules/opensearch/OpenSearchZoneAwareness.ts
@@ -6,42 +6,45 @@ import { parse } from 'path';
 import { CfnDomain as LegacyCfnDomain } from '@aws-cdk/aws-elasticsearch';
 import { CfnDomain } from '@aws-cdk/aws-opensearchservice';
 import { CfnResource, Stack } from '@aws-cdk/core';
-import { resolveIfPrimitive } from '../../nag-pack';
+import { resolveIfPrimitive, NagRuleCompliance } from '../../nag-pack';
 
 /**
  * OpenSearch Service domains have Zone Awareness enabled
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof LegacyCfnDomain) {
       const elasticsearchClusterConfig = Stack.of(node).resolve(
         node.elasticsearchClusterConfig
       );
       if (elasticsearchClusterConfig == undefined) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
       const zoneAwarenessEnabled = resolveIfPrimitive(
         node,
         elasticsearchClusterConfig.zoneAwarenessEnabled
       );
       if (!zoneAwarenessEnabled) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
     } else if (node instanceof CfnDomain) {
       const clusterConfig = Stack.of(node).resolve(node.clusterConfig);
       if (clusterConfig == undefined) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
       const zoneAwarenessEnabled = resolveIfPrimitive(
         node,
         clusterConfig.zoneAwarenessEnabled
       );
       if (!zoneAwarenessEnabled) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/quicksight/QuicksightSSLConnections.ts
+++ b/src/rules/quicksight/QuicksightSSLConnections.ts
@@ -5,24 +5,26 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnDataSource } from '@aws-cdk/aws-quicksight';
 import { CfnResource, Stack } from '@aws-cdk/core';
-import { resolveIfPrimitive } from '../../nag-pack';
+import { resolveIfPrimitive, NagRuleCompliance } from '../../nag-pack';
 
 /**
  * Quicksight uses SSL when connecting to a data source
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnDataSource) {
       const sslProperties = Stack.of(node).resolve(node.sslProperties);
       if (sslProperties != undefined) {
         const disableSsl = resolveIfPrimitive(node, sslProperties.disableSsl);
         if (disableSsl === true) {
-          return false;
+          return NagRuleCompliance.NON_COMPLIANT;
         }
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/rds/AuroraMySQLBacktrack.ts
+++ b/src/rules/rds/AuroraMySQLBacktrack.ts
@@ -5,24 +5,26 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnDBCluster } from '@aws-cdk/aws-rds';
 import { CfnResource } from '@aws-cdk/core';
-import { resolveIfPrimitive } from '../../nag-pack';
+import { resolveIfPrimitive, NagRuleCompliance } from '../../nag-pack';
 
 /**
  * RDS Aurora serverless clusters have Log Exports enabled
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnDBCluster) {
       const engine = resolveIfPrimitive(node, node.engine).toLowerCase();
       const backtrackWindow = resolveIfPrimitive(node, node.backtrackWindow);
       if (engine == 'aurora' || engine == 'aurora-mysql') {
         if (backtrackWindow == undefined || backtrackWindow == 0) {
-          return false;
+          return NagRuleCompliance.NON_COMPLIANT;
         }
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/rds/AuroraMySQLLogging.ts
+++ b/src/rules/rds/AuroraMySQLLogging.ts
@@ -5,14 +5,14 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnDBCluster } from '@aws-cdk/aws-rds';
 import { CfnResource } from '@aws-cdk/core';
-import { resolveIfPrimitive } from '../../nag-pack';
+import { resolveIfPrimitive, NagRuleCompliance } from '../../nag-pack';
 
 /**
  * RDS Aurora MySQL serverless clusters have audit, error, general, and slowquery Log Exports enabled
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnDBCluster) {
       const engine = resolveIfPrimitive(node, node.engine).toLowerCase();
       const engineMode = resolveIfPrimitive(
@@ -26,16 +26,21 @@ export default Object.defineProperty(
           engine.toLowerCase() == 'aurora-mysql')
       ) {
         if (node.enableCloudwatchLogsExports == undefined) {
-          return false;
+          return NagRuleCompliance.NON_COMPLIANT;
         }
         const needed = ['audit', 'error', 'general', 'slowquery'];
         const exports = node.enableCloudwatchLogsExports.map((i) => {
           return i.toLowerCase();
         });
-        return needed.every((i) => exports.includes(i));
+        const compliant = needed.every((i) => exports.includes(i));
+        if (compliant !== true) {
+          return NagRuleCompliance.NON_COMPLIANT;
+        }
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/rds/AuroraMySQLPostgresIAMAuth.ts
+++ b/src/rules/rds/AuroraMySQLPostgresIAMAuth.ts
@@ -5,30 +5,31 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnDBCluster } from '@aws-cdk/aws-rds';
 import { CfnResource } from '@aws-cdk/core';
-import { resolveIfPrimitive } from '../../nag-pack';
+import { resolveIfPrimitive, NagRuleCompliance } from '../../nag-pack';
 
 /**
  * RDS Aurora MySQL/PostgresSQL clusters have IAM Database Authentication enabled
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnDBCluster) {
       if (node.engine.toLowerCase().includes('aurora')) {
         if (node.enableIamDatabaseAuthentication == undefined) {
-          return false;
+          return NagRuleCompliance.NON_COMPLIANT;
         }
         const iamAuth = resolveIfPrimitive(
           node,
           node.enableIamDatabaseAuthentication
         );
         if (iamAuth == false) {
-          return false;
+          return NagRuleCompliance.NON_COMPLIANT;
         }
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/rds/RDSAutomaticMinorVersionUpgradeEnabled.ts
+++ b/src/rules/rds/RDSAutomaticMinorVersionUpgradeEnabled.ts
@@ -5,24 +5,26 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnDBInstance } from '@aws-cdk/aws-rds';
 import { CfnResource } from '@aws-cdk/core';
-import { resolveIfPrimitive } from '../../nag-pack';
+import { resolveIfPrimitive, NagRuleCompliance } from '../../nag-pack';
 
 /**
  * RDS DB instances have automatic minor version upgrades enabled
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnDBInstance) {
       const autoMinorVersionUpgrade = resolveIfPrimitive(
         node,
         node.autoMinorVersionUpgrade
       );
       if (autoMinorVersionUpgrade === false) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/rds/RDSEnhancedMonitoringEnabled.ts
+++ b/src/rules/rds/RDSEnhancedMonitoringEnabled.ts
@@ -5,24 +5,26 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnDBInstance } from '@aws-cdk/aws-rds';
 import { CfnResource } from '@aws-cdk/core';
-import { resolveIfPrimitive } from '../../nag-pack';
+import { resolveIfPrimitive, NagRuleCompliance } from '../../nag-pack';
 
 /**
  * RDS DB instances have enhanced monitoring enabled
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnDBInstance) {
       const enhancedMonitoring = resolveIfPrimitive(
         node,
         node.monitoringInterval
       );
       if (enhancedMonitoring == undefined || enhancedMonitoring <= 0) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/rds/RDSInBackupPlan.ts
+++ b/src/rules/rds/RDSInBackupPlan.ts
@@ -6,7 +6,10 @@ import { parse } from 'path';
 import { CfnBackupSelection } from '@aws-cdk/aws-backup';
 import { CfnDBInstance } from '@aws-cdk/aws-rds';
 import { CfnResource, Stack } from '@aws-cdk/core';
-import { resolveResourceFromInstrinsic } from '../../nag-pack';
+import {
+  resolveResourceFromInstrinsic,
+  NagRuleCompliance,
+} from '../../nag-pack';
 
 /**
  * RDS DB Instances are part of AWS Backup plan(s)
@@ -14,7 +17,7 @@ import { resolveResourceFromInstrinsic } from '../../nag-pack';
  */
 
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnDBInstance) {
       const dbLogicalId = resolveResourceFromInstrinsic(node, node.ref);
       let found = false;
@@ -27,10 +30,12 @@ export default Object.defineProperty(
         }
       }
       if (!found) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/rds/RDSInstanceBackupEnabled.ts
+++ b/src/rules/rds/RDSInstanceBackupEnabled.ts
@@ -5,21 +5,23 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnDBInstance } from '@aws-cdk/aws-rds';
 import { CfnResource } from '@aws-cdk/core';
-import { resolveIfPrimitive } from '../../nag-pack';
+import { resolveIfPrimitive, NagRuleCompliance } from '../../nag-pack';
 
 /**
  * RDS DB instances have backup enabled
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnDBInstance) {
       const backup = resolveIfPrimitive(node, node.backupRetentionPeriod);
       if (backup !== undefined && backup <= 0) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/rds/RDSInstanceDeletionProtectionEnabled.ts
+++ b/src/rules/rds/RDSInstanceDeletionProtectionEnabled.ts
@@ -5,26 +5,26 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnDBCluster, CfnDBInstance } from '@aws-cdk/aws-rds';
 import { CfnResource } from '@aws-cdk/core';
-import { resolveIfPrimitive } from '../../nag-pack';
+import { resolveIfPrimitive, NagRuleCompliance } from '../../nag-pack';
 
 /**
  *  RDS DB instances and Aurora DB clusters have Deletion Protection enabled
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnDBCluster) {
       if (node.deletionProtection == undefined) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
       const deletionProtection = resolveIfPrimitive(
         node,
         node.deletionProtection
       );
       if (deletionProtection == false) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
-      return true;
+      return NagRuleCompliance.COMPLIANT;
     } else if (node instanceof CfnDBInstance) {
       const deletionProtection = resolveIfPrimitive(
         node,
@@ -35,11 +35,12 @@ export default Object.defineProperty(
         (deletionProtection == false || deletionProtection == undefined) &&
         (engine == undefined || !engine.toLowerCase().includes('aurora'))
       ) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
-      return true;
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/rds/RDSInstancePublicAccess.ts
+++ b/src/rules/rds/RDSInstancePublicAccess.ts
@@ -5,22 +5,23 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnDBInstance } from '@aws-cdk/aws-rds';
 import { CfnResource } from '@aws-cdk/core';
-import { resolveIfPrimitive } from '../../nag-pack';
+import { resolveIfPrimitive, NagRuleCompliance } from '../../nag-pack';
 
 /**
  * RDS DB instances are not publicly accessible
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnDBInstance) {
       const publicAccess = resolveIfPrimitive(node, node.publiclyAccessible);
       if (publicAccess !== false) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
-      return true;
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/rds/RDSLoggingEnabled.ts
+++ b/src/rules/rds/RDSLoggingEnabled.ts
@@ -5,21 +5,21 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnDBInstance } from '@aws-cdk/aws-rds';
 import { CfnResource, Stack } from '@aws-cdk/core';
-import { resolveIfPrimitive } from '../../nag-pack';
+import { resolveIfPrimitive, NagRuleCompliance } from '../../nag-pack';
 
 /**
  * RDS DB instances are configured to export all possible log types to CloudWatch
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnDBInstance) {
       const dbType = JSON.stringify(resolveIfPrimitive(node, node.engine));
       const dbLogs = JSON.stringify(
         Stack.of(node).resolve(node.enableCloudwatchLogsExports)
       );
       if (dbLogs == undefined) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
 
       if (dbType.includes('mariadb') || dbType.includes('mysql')) {
@@ -31,12 +31,12 @@ export default Object.defineProperty(
             dbLogs.includes('slowquery')
           )
         )
-          return false;
+          return NagRuleCompliance.NON_COMPLIANT;
       }
 
       if (dbType.includes('postgres')) {
         if (!(dbLogs.includes('postgresql') && dbLogs.includes('upgrade')))
-          return false;
+          return NagRuleCompliance.NON_COMPLIANT;
       }
 
       if (dbType.includes('oracle')) {
@@ -49,15 +49,17 @@ export default Object.defineProperty(
             dbLogs.includes('trace')
           )
         )
-          return false;
+          return NagRuleCompliance.NON_COMPLIANT;
       }
 
       if (dbType.includes('sqlserver')) {
         if (!(dbLogs.includes('agent') && dbLogs.includes('error')))
-          return false;
+          return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/rds/RDSMultiAZSupport.ts
+++ b/src/rules/rds/RDSMultiAZSupport.ts
@@ -5,14 +5,14 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnDBInstance } from '@aws-cdk/aws-rds';
 import { CfnResource } from '@aws-cdk/core';
-import { resolveIfPrimitive } from '../../nag-pack';
+import { resolveIfPrimitive, NagRuleCompliance } from '../../nag-pack';
 
 /**
  *  Non-Aurora RDS DB instances have multi-AZ support enabled
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnDBInstance) {
       const multiAz = resolveIfPrimitive(node, node.multiAz);
       const engine = resolveIfPrimitive(node, node.engine);
@@ -20,10 +20,12 @@ export default Object.defineProperty(
         !multiAz &&
         (engine == undefined || !engine.toLowerCase().includes('aurora'))
       ) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/rds/RDSNonDefaultPort.ts
+++ b/src/rules/rds/RDSNonDefaultPort.ts
@@ -5,17 +5,17 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnDBCluster, CfnDBInstance } from '@aws-cdk/aws-rds';
 import { CfnResource } from '@aws-cdk/core';
-import { resolveIfPrimitive } from '../../nag-pack';
+import { resolveIfPrimitive, NagRuleCompliance } from '../../nag-pack';
 
 /**
  *  RDS DB instances and Aurora DB clusters do not use the default endpoint ports
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnDBCluster) {
       if (node.port == undefined) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
       const port = resolveIfPrimitive(node, node.port);
       const engine = resolveIfPrimitive(node, node.engine).toLowerCase();
@@ -25,41 +25,42 @@ export default Object.defineProperty(
         engineMode.toLowerCase() == 'provisioned'
       ) {
         if (engine.includes('aurora') && port == 3306) {
-          return false;
+          return NagRuleCompliance.NON_COMPLIANT;
         }
       } else if (
         (engine == 'aurora' || engine == 'aurora-mysql') &&
         port == 3306
       ) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       } else if (engine == 'aurora-postgresql' && port == 5432) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
-      return true;
+      return NagRuleCompliance.COMPLIANT;
     } else if (node instanceof CfnDBInstance) {
       if (node.engine == undefined) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
       const port = resolveIfPrimitive(node, node.port);
       const engine = resolveIfPrimitive(node, node.engine).toLowerCase();
       if (port == undefined) {
         if (!engine.includes('aurora')) {
-          return false;
+          return NagRuleCompliance.NON_COMPLIANT;
         }
       } else {
         if ((engine == 'mariadb' || engine == 'mysql') && port == 3306) {
-          return false;
+          return NagRuleCompliance.NON_COMPLIANT;
         } else if (engine == 'postgres' && port == 5432) {
-          return false;
+          return NagRuleCompliance.NON_COMPLIANT;
         } else if (engine.includes('oracle') && port == 1521) {
-          return false;
+          return NagRuleCompliance.NON_COMPLIANT;
         } else if (engine.includes('sqlserver') && port == 1433) {
-          return false;
+          return NagRuleCompliance.NON_COMPLIANT;
         }
       }
-      return true;
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/rds/RDSStorageEncrypted.ts
+++ b/src/rules/rds/RDSStorageEncrypted.ts
@@ -5,22 +5,23 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnDBCluster, CfnDBInstance } from '@aws-cdk/aws-rds';
 import { CfnResource } from '@aws-cdk/core';
-import { resolveIfPrimitive } from '../../nag-pack';
+import { resolveIfPrimitive, NagRuleCompliance } from '../../nag-pack';
 
 /**
  * RDS DB instances and Aurora DB clusters have storage encryption enabled
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnDBCluster) {
       if (node.storageEncrypted == undefined) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
       const encrypted = resolveIfPrimitive(node, node.storageEncrypted);
       if (encrypted == false) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
     } else if (node instanceof CfnDBInstance) {
       const encrypted = resolveIfPrimitive(node, node.storageEncrypted);
       if (
@@ -28,10 +29,12 @@ export default Object.defineProperty(
         (node.engine == undefined ||
           !node.engine.toLowerCase().includes('aurora'))
       ) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/redshift/RedshiftBackupEnabled.ts
+++ b/src/rules/redshift/RedshiftBackupEnabled.ts
@@ -5,14 +5,14 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnCluster } from '@aws-cdk/aws-redshift';
 import { CfnResource } from '@aws-cdk/core';
-import { resolveIfPrimitive } from '../../nag-pack';
+import { resolveIfPrimitive, NagRuleCompliance } from '../../nag-pack';
 
 /**
  * Redshift clusters have automated snapshots enabled and the retention period is between 1 and 35 days
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnCluster) {
       const automatedSnapshotRetentionPeriod = resolveIfPrimitive(
         node,
@@ -22,10 +22,12 @@ export default Object.defineProperty(
         automatedSnapshotRetentionPeriod != undefined &&
         automatedSnapshotRetentionPeriod == 0
       ) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/redshift/RedshiftClusterAuditLogging.ts
+++ b/src/rules/redshift/RedshiftClusterAuditLogging.ts
@@ -5,20 +5,23 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnCluster } from '@aws-cdk/aws-redshift';
 import { CfnResource, Stack } from '@aws-cdk/core';
+import { NagRuleCompliance } from '../../nag-pack';
 
 /**
  * Redshift clusters have audit logging enabled
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnCluster) {
       const loggingProperties = Stack.of(node).resolve(node.loggingProperties);
       if (loggingProperties == undefined) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/redshift/RedshiftClusterConfiguration.ts
+++ b/src/rules/redshift/RedshiftClusterConfiguration.ts
@@ -5,22 +5,24 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnCluster } from '@aws-cdk/aws-redshift';
 import { CfnResource, Stack } from '@aws-cdk/core';
-import { resolveIfPrimitive } from '../../nag-pack';
+import { resolveIfPrimitive, NagRuleCompliance } from '../../nag-pack';
 
 /**
  * Redshift clusters have encryption and audit logging enabled
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnCluster) {
       const encrypted = resolveIfPrimitive(node, node.encrypted);
       const loggingProperties = Stack.of(node).resolve(node.loggingProperties);
       if (!encrypted || loggingProperties == undefined) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/redshift/RedshiftClusterEncryptionAtRest.ts
+++ b/src/rules/redshift/RedshiftClusterEncryptionAtRest.ts
@@ -5,24 +5,26 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnCluster } from '@aws-cdk/aws-redshift';
 import { CfnResource } from '@aws-cdk/core';
-import { resolveIfPrimitive } from '../../nag-pack';
+import { resolveIfPrimitive, NagRuleCompliance } from '../../nag-pack';
 
 /**
  * Redshift clusters have encryption at rest enabled
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnCluster) {
       if (node.encrypted == undefined) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
       const encrypted = resolveIfPrimitive(node, node.encrypted);
       if (!encrypted) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/redshift/RedshiftClusterInVPC.ts
+++ b/src/rules/redshift/RedshiftClusterInVPC.ts
@@ -5,22 +5,25 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnCluster } from '@aws-cdk/aws-redshift';
 import { CfnResource } from '@aws-cdk/core';
+import { NagRuleCompliance } from '../../nag-pack';
 
 /**
  * Redshift clusters are provisioned in a VPC
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnCluster) {
       if (
         node.clusterSubnetGroupName == undefined ||
         node.clusterSubnetGroupName.length == 0
       ) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/redshift/RedshiftClusterMaintenanceSettings.ts
+++ b/src/rules/redshift/RedshiftClusterMaintenanceSettings.ts
@@ -5,14 +5,14 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnCluster } from '@aws-cdk/aws-redshift';
 import { CfnResource } from '@aws-cdk/core';
-import { resolveIfPrimitive } from '../../nag-pack';
+import { resolveIfPrimitive, NagRuleCompliance } from '../../nag-pack';
 
 /**
  * Redshift clusters have version upgrades enabled, automated snapshot retention periods enabled, and explicit maintenance windows configured
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnCluster) {
       const allowVersionUpgrade = resolveIfPrimitive(
         node,
@@ -28,10 +28,12 @@ export default Object.defineProperty(
         node.preferredMaintenanceWindow == undefined ||
         allowVersionUpgrade === false
       ) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/redshift/RedshiftClusterNonDefaultPort.ts
+++ b/src/rules/redshift/RedshiftClusterNonDefaultPort.ts
@@ -5,21 +5,23 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnCluster } from '@aws-cdk/aws-redshift';
 import { CfnResource } from '@aws-cdk/core';
-import { resolveIfPrimitive } from '../../nag-pack';
+import { resolveIfPrimitive, NagRuleCompliance } from '../../nag-pack';
 
 /**
  * Redshift clusters do not use the default endpoint port
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnCluster) {
       const port = resolveIfPrimitive(node, node.port);
       if (port == undefined || port == 5439) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/redshift/RedshiftClusterNonDefaultUsername.ts
+++ b/src/rules/redshift/RedshiftClusterNonDefaultUsername.ts
@@ -5,21 +5,23 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnCluster } from '@aws-cdk/aws-redshift';
 import { CfnResource } from '@aws-cdk/core';
-import { resolveIfPrimitive } from '../../nag-pack';
+import { resolveIfPrimitive, NagRuleCompliance } from '../../nag-pack';
 
 /**
  * Redshift clusters use custom user names vice the default (awsuser)
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnCluster) {
       const masterUsername = resolveIfPrimitive(node, node.masterUsername);
       if (masterUsername == 'awsuser') {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/redshift/RedshiftClusterPublicAccess.ts
+++ b/src/rules/redshift/RedshiftClusterPublicAccess.ts
@@ -5,21 +5,23 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnCluster } from '@aws-cdk/aws-redshift';
 import { CfnResource } from '@aws-cdk/core';
-import { resolveIfPrimitive } from '../../nag-pack';
+import { resolveIfPrimitive, NagRuleCompliance } from '../../nag-pack';
 
 /**
  * Redshift clusters do not allow public access
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnCluster) {
       const publicAccess = resolveIfPrimitive(node, node.publiclyAccessible);
       if (publicAccess === true) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/redshift/RedshiftClusterUserActivityLogging.ts
+++ b/src/rules/redshift/RedshiftClusterUserActivityLogging.ts
@@ -5,21 +5,24 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnCluster, CfnClusterParameterGroup } from '@aws-cdk/aws-redshift';
 import { CfnResource, Stack } from '@aws-cdk/core';
-import { resolveResourceFromInstrinsic } from '../../nag-pack';
+import {
+  resolveResourceFromInstrinsic,
+  NagRuleCompliance,
+} from '../../nag-pack';
 
 /**
  * Redshift clusters have user user activity logging enabled
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnCluster) {
       const clusterParameterGroupName = resolveResourceFromInstrinsic(
         node,
         node.clusterParameterGroupName
       );
       if (clusterParameterGroupName === undefined) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
       let found = false;
       for (const child of Stack.of(node).node.findAll()) {
@@ -35,10 +38,12 @@ export default Object.defineProperty(
         }
       }
       if (!found) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/redshift/RedshiftClusterVersionUpgrade.ts
+++ b/src/rules/redshift/RedshiftClusterVersionUpgrade.ts
@@ -5,24 +5,26 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnCluster } from '@aws-cdk/aws-redshift';
 import { CfnResource } from '@aws-cdk/core';
-import { resolveIfPrimitive } from '../../nag-pack';
+import { resolveIfPrimitive, NagRuleCompliance } from '../../nag-pack';
 
 /**
  * Redshift clusters have version upgrade enabled
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnCluster) {
       const allowVersionUpgrade = resolveIfPrimitive(
         node,
         node.allowVersionUpgrade
       );
       if (allowVersionUpgrade === false) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/redshift/RedshiftEnhancedVPCRoutingEnabled.ts
+++ b/src/rules/redshift/RedshiftEnhancedVPCRoutingEnabled.ts
@@ -5,24 +5,26 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnCluster } from '@aws-cdk/aws-redshift';
 import { CfnResource } from '@aws-cdk/core';
-import { resolveIfPrimitive } from '../../nag-pack';
+import { resolveIfPrimitive, NagRuleCompliance } from '../../nag-pack';
 
 /**
  * Redshift clusters have enhanced VPC routing enabled
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnCluster) {
       const enhancedVpcRouting = resolveIfPrimitive(
         node,
         node.enhancedVpcRouting
       );
       if (enhancedVpcRouting !== true) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/redshift/RedshiftRequireTlsSSL.ts
+++ b/src/rules/redshift/RedshiftRequireTlsSSL.ts
@@ -5,7 +5,10 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnCluster, CfnClusterParameterGroup } from '@aws-cdk/aws-redshift';
 import { CfnResource, Stack } from '@aws-cdk/core';
-import { resolveResourceFromInstrinsic } from '../../nag-pack';
+import {
+  resolveResourceFromInstrinsic,
+  NagRuleCompliance,
+} from '../../nag-pack';
 
 /**
  * Redshift clusters require TLS/SSL encryption
@@ -13,14 +16,14 @@ import { resolveResourceFromInstrinsic } from '../../nag-pack';
  */
 
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnCluster) {
       const clusterParameterGroupName = resolveResourceFromInstrinsic(
         node,
         node.clusterParameterGroupName
       );
       if (clusterParameterGroupName === undefined) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
       let found = false;
       for (const child of Stack.of(node).node.findAll()) {
@@ -32,10 +35,12 @@ export default Object.defineProperty(
         }
       }
       if (!found) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/s3/S3BucketDefaultLockEnabled.ts
+++ b/src/rules/s3/S3BucketDefaultLockEnabled.ts
@@ -5,14 +5,14 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnBucket } from '@aws-cdk/aws-s3';
 import { CfnResource, Stack } from '@aws-cdk/core';
-import { resolveIfPrimitive } from '../../nag-pack';
+import { resolveIfPrimitive, NagRuleCompliance } from '../../nag-pack';
 
 /**
  * S3 Buckets have object lock enabled
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnBucket) {
       const objectLockEnabled = resolveIfPrimitive(
         node,
@@ -27,10 +27,12 @@ export default Object.defineProperty(
         resolveIfPrimitive(node, objectLockConfiguration.objectLockEnabled) !==
           'Enabled'
       ) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/s3/S3BucketLevelPublicAccessProhibited.ts
+++ b/src/rules/s3/S3BucketLevelPublicAccessProhibited.ts
@@ -5,17 +5,17 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnBucket } from '@aws-cdk/aws-s3';
 import { CfnResource, Stack } from '@aws-cdk/core';
-import { resolveIfPrimitive } from '../../nag-pack';
+import { resolveIfPrimitive, NagRuleCompliance } from '../../nag-pack';
 
 /**
  * S3 Buckets prohibit public access through bucket level settings
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnBucket) {
       if (node.publicAccessBlockConfiguration == undefined) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
       const publicAccess = Stack.of(node).resolve(
         node.publicAccessBlockConfiguration
@@ -42,10 +42,12 @@ export default Object.defineProperty(
         ignorePublicAcls !== true ||
         restrictPublicBuckets !== true
       ) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/s3/S3BucketLoggingEnabled.ts
+++ b/src/rules/s3/S3BucketLoggingEnabled.ts
@@ -5,13 +5,14 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnBucket } from '@aws-cdk/aws-s3';
 import { CfnResource, Stack } from '@aws-cdk/core';
+import { NagRuleCompliance } from '../../nag-pack';
 
 /**
  * S3 Buckets have server access logs enabled
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnBucket) {
       const logging = Stack.of(node).resolve(node.loggingConfiguration);
       if (
@@ -19,10 +20,12 @@ export default Object.defineProperty(
         (logging.destinationBucketName == undefined &&
           logging.logFilePrefix == undefined)
       ) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/s3/S3BucketPublicReadProhibited.ts
+++ b/src/rules/s3/S3BucketPublicReadProhibited.ts
@@ -5,14 +5,14 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnBucket } from '@aws-cdk/aws-s3';
 import { CfnResource, Stack } from '@aws-cdk/core';
-import { resolveIfPrimitive } from '../../nag-pack';
+import { resolveIfPrimitive, NagRuleCompliance } from '../../nag-pack';
 
 /**
  * S3 Buckets prohibit public read access through their Block Public Access configurations and bucket ACLs
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnBucket) {
       const publicAccessBlockConfiguration = Stack.of(node).resolve(
         node.publicAccessBlockConfiguration
@@ -24,7 +24,7 @@ export default Object.defineProperty(
           publicAccessBlockConfiguration.blockPublicPolicy
         ) !== true
       ) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
       const accessControl = resolveIfPrimitive(node, node.accessControl);
       const blockPublicAcls = resolveIfPrimitive(
@@ -36,10 +36,12 @@ export default Object.defineProperty(
           accessControl === 'PublicReadWrite') &&
         blockPublicAcls !== true
       ) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/s3/S3BucketPublicWriteProhibited.ts
+++ b/src/rules/s3/S3BucketPublicWriteProhibited.ts
@@ -5,14 +5,14 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnBucket } from '@aws-cdk/aws-s3';
 import { CfnResource, Stack } from '@aws-cdk/core';
-import { resolveIfPrimitive } from '../../nag-pack';
+import { resolveIfPrimitive, NagRuleCompliance } from '../../nag-pack';
 
 /**
  * S3 Buckets prohibit public write access through their Block Public Access configurations and bucket ACLs
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnBucket) {
       const publicAccessBlockConfiguration = Stack.of(node).resolve(
         node.publicAccessBlockConfiguration
@@ -24,7 +24,7 @@ export default Object.defineProperty(
           publicAccessBlockConfiguration.blockPublicPolicy
         ) !== true
       ) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
       const accessControl = resolveIfPrimitive(node, node.accessControl);
       const blockPublicAcls = resolveIfPrimitive(
@@ -32,10 +32,12 @@ export default Object.defineProperty(
         publicAccessBlockConfiguration.blockPublicAcls
       );
       if (accessControl === 'PublicReadWrite' && blockPublicAcls !== true) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/s3/S3BucketReplicationEnabled.ts
+++ b/src/rules/s3/S3BucketReplicationEnabled.ts
@@ -5,17 +5,18 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnBucket } from '@aws-cdk/aws-s3';
 import { CfnResource, Stack } from '@aws-cdk/core';
+import { NagRuleCompliance } from '../../nag-pack';
 
 /**
  * S3 Buckets have replication enabled
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnBucket) {
       const replication = Stack.of(node).resolve(node.replicationConfiguration);
       if (replication === undefined) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
       const rules = Stack.of(node).resolve(replication.rules);
       let found = false;
@@ -27,10 +28,12 @@ export default Object.defineProperty(
         }
       }
       if (!found) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/s3/S3BucketServerSideEncryptionEnabled.ts
+++ b/src/rules/s3/S3BucketServerSideEncryptionEnabled.ts
@@ -5,21 +5,21 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnBucket } from '@aws-cdk/aws-s3';
 import { CfnResource, Stack } from '@aws-cdk/core';
-import { resolveIfPrimitive } from '../../nag-pack';
+import { resolveIfPrimitive, NagRuleCompliance } from '../../nag-pack';
 
 /**
  * S3 Buckets have default server-side encryption enabled
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnBucket) {
       if (node.bucketEncryption == undefined) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
       const encryption = Stack.of(node).resolve(node.bucketEncryption);
       if (encryption.serverSideEncryptionConfiguration == undefined) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
       const sse = Stack.of(node).resolve(
         encryption.serverSideEncryptionConfiguration
@@ -29,7 +29,7 @@ export default Object.defineProperty(
           rule.serverSideEncryptionByDefault
         );
         if (defaultEncryption == undefined) {
-          return false;
+          return NagRuleCompliance.NON_COMPLIANT;
         }
         const sseAlgorithm = resolveIfPrimitive(
           node,
@@ -39,11 +39,13 @@ export default Object.defineProperty(
           sseAlgorithm.toLowerCase() != 'aes256' &&
           sseAlgorithm.toLowerCase() != 'aws:kms'
         ) {
-          return false;
+          return NagRuleCompliance.NON_COMPLIANT;
         }
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/s3/S3BucketVersioningEnabled.ts
+++ b/src/rules/s3/S3BucketVersioningEnabled.ts
@@ -5,14 +5,14 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnBucket } from '@aws-cdk/aws-s3';
 import { CfnResource, Stack } from '@aws-cdk/core';
-import { resolveIfPrimitive } from '../../nag-pack';
+import { resolveIfPrimitive, NagRuleCompliance } from '../../nag-pack';
 
 /**
  * S3 Buckets have versioningConfiguration enabled
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnBucket) {
       const versioningConfiguration = Stack.of(node).resolve(
         node.versioningConfiguration
@@ -21,10 +21,12 @@ export default Object.defineProperty(
         versioningConfiguration === undefined ||
         resolveIfPrimitive(node, versioningConfiguration.status) === 'Suspended'
       ) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/s3/S3DefaultEncryptionKMS.ts
+++ b/src/rules/s3/S3DefaultEncryptionKMS.ts
@@ -5,21 +5,21 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnBucket } from '@aws-cdk/aws-s3';
 import { CfnResource, Stack } from '@aws-cdk/core';
-import { resolveIfPrimitive } from '../../nag-pack';
+import { resolveIfPrimitive, NagRuleCompliance } from '../../nag-pack';
 
 /**
  * S3 Buckets are encrypted with a KMS Key by default
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnBucket) {
       if (node.bucketEncryption == undefined) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
       const encryption = Stack.of(node).resolve(node.bucketEncryption);
       if (encryption.serverSideEncryptionConfiguration == undefined) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
       const sse = Stack.of(node).resolve(
         encryption.serverSideEncryptionConfiguration
@@ -29,18 +29,20 @@ export default Object.defineProperty(
           rule.serverSideEncryptionByDefault
         );
         if (defaultEncryption == undefined) {
-          return false;
+          return NagRuleCompliance.NON_COMPLIANT;
         }
         const sseAlgorithm = resolveIfPrimitive(
           node,
           defaultEncryption.sseAlgorithm
         );
         if (sseAlgorithm.toLowerCase() != 'aws:kms') {
-          return false;
+          return NagRuleCompliance.NON_COMPLIANT;
         }
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/sagemaker/SageMakerEndpointConfigurationKMSKeyConfigured.ts
+++ b/src/rules/sagemaker/SageMakerEndpointConfigurationKMSKeyConfigured.ts
@@ -5,21 +5,23 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnEndpointConfig } from '@aws-cdk/aws-sagemaker';
 import { CfnResource, Stack } from '@aws-cdk/core';
+import { NagRuleCompliance } from '../../nag-pack';
 
 /**
  * SageMaker endpoints utilize a KMS key
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnEndpointConfig) {
-      //Does this endpoint have a KMS key ID?
       const kmsKey = Stack.of(node).resolve(node.kmsKeyId);
       if (kmsKey == undefined) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/sagemaker/SageMakerNotebookInVPC.ts
+++ b/src/rules/sagemaker/SageMakerNotebookInVPC.ts
@@ -5,20 +5,23 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnNotebookInstance } from '@aws-cdk/aws-sagemaker';
 import { CfnResource, Stack } from '@aws-cdk/core';
+import { NagRuleCompliance } from '../../nag-pack';
 
 /**
  * SageMaker notebook instances are provisioned inside a VPC
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnNotebookInstance) {
       const subnetId = Stack.of(node).resolve(node.subnetId);
       if (subnetId == undefined) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/sagemaker/SageMakerNotebookInstanceKMSKeyConfigured.ts
+++ b/src/rules/sagemaker/SageMakerNotebookInstanceKMSKeyConfigured.ts
@@ -5,20 +5,23 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnNotebookInstance } from '@aws-cdk/aws-sagemaker';
 import { CfnResource, Stack } from '@aws-cdk/core';
+import { NagRuleCompliance } from '../../nag-pack';
 
 /**
  * SageMaker notebook instances utilize KMS keys for encryption at rest
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnNotebookInstance) {
       const kmsKey = Stack.of(node).resolve(node.kmsKeyId);
       if (kmsKey == undefined) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/sagemaker/SageMakerNotebookNoDirectInternetAccess.ts
+++ b/src/rules/sagemaker/SageMakerNotebookNoDirectInternetAccess.ts
@@ -5,14 +5,14 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnNotebookInstance } from '@aws-cdk/aws-sagemaker';
 import { CfnResource } from '@aws-cdk/core';
-import { resolveIfPrimitive } from '../../nag-pack';
+import { resolveIfPrimitive, NagRuleCompliance } from '../../nag-pack';
 
 /**
  * SageMaker notebook instances have direct internet access disabled
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnNotebookInstance) {
       const directInternetAccess = resolveIfPrimitive(
         node,
@@ -22,10 +22,12 @@ export default Object.defineProperty(
         directInternetAccess == undefined ||
         directInternetAccess != 'Disabled'
       ) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/secretsmanager/SecretsManagerRotationEnabled.ts
+++ b/src/rules/secretsmanager/SecretsManagerRotationEnabled.ts
@@ -9,14 +9,17 @@ import {
   CfnSecretTargetAttachment,
 } from '@aws-cdk/aws-secretsmanager';
 import { CfnResource, Stack } from '@aws-cdk/core';
-import { resolveResourceFromInstrinsic } from '../../nag-pack';
+import {
+  resolveResourceFromInstrinsic,
+  NagRuleCompliance,
+} from '../../nag-pack';
 
 /**
  * Secrets have automatic rotation scheduled
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnSecret) {
       const secretLogicalId = resolveResourceFromInstrinsic(node, node.ref);
       const secretTargetAttachmentLogicalIds = Array<string>();
@@ -30,7 +33,7 @@ export default Object.defineProperty(
         }
       }
       if (cfnRotationSchedules.length === 0) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
       let found = false;
       for (const child of cfnSecretTargetAttachments) {
@@ -55,10 +58,12 @@ export default Object.defineProperty(
         }
       }
       if (!found) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/secretsmanager/SecretsManagerUsingKMSKey.ts
+++ b/src/rules/secretsmanager/SecretsManagerUsingKMSKey.ts
@@ -5,21 +5,23 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnSecret } from '@aws-cdk/aws-secretsmanager';
 import { CfnResource } from '@aws-cdk/core';
-import { resolveIfPrimitive } from '../../nag-pack';
+import { resolveIfPrimitive, NagRuleCompliance } from '../../nag-pack';
 
 /**
  * Secrets are encrypted with KMS Customer managed keys
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnSecret) {
       const kmsKeyId = resolveIfPrimitive(node, node.kmsKeyId);
       if (kmsKeyId === undefined || kmsKeyId === 'aws/secretsmanager') {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/sns/SNSEncryptedKMS.ts
+++ b/src/rules/sns/SNSEncryptedKMS.ts
@@ -5,20 +5,23 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnTopic } from '@aws-cdk/aws-sns';
 import { CfnResource, Stack } from '@aws-cdk/core';
+import { NagRuleCompliance } from '../../nag-pack';
 
 /**
  * SNS topics are encrypted via KMS
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnTopic) {
       const topicKey = Stack.of(node).resolve(node.kmsMasterKeyId);
       if (topicKey == undefined) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/sqs/SQSQueueDLQ.ts
+++ b/src/rules/sqs/SQSQueueDLQ.ts
@@ -5,20 +5,23 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnQueue } from '@aws-cdk/aws-sqs';
 import { CfnResource, Stack } from '@aws-cdk/core';
+import { NagRuleCompliance } from '../../nag-pack';
 
 /**
  * SQS queues have a dead-letter queue enabled or have a cdk_nag rule suppression indicating they are a dead-letter queue.
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnQueue) {
       const redrivePolicy = Stack.of(node).resolve(node.redrivePolicy);
       if (redrivePolicy == undefined) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/sqs/SQSQueueSSE.ts
+++ b/src/rules/sqs/SQSQueueSSE.ts
@@ -5,20 +5,23 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnQueue } from '@aws-cdk/aws-sqs';
 import { CfnResource, Stack } from '@aws-cdk/core';
+import { NagRuleCompliance } from '../../nag-pack';
 
 /**
  * SQS queues have server-side encryption enabled
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnQueue) {
       const kmsMasterKeyId = Stack.of(node).resolve(node.kmsMasterKeyId);
       if (kmsMasterKeyId == undefined) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/stepfunctions/StepFunctionStateMachineAllLogsToCloudWatch.ts
+++ b/src/rules/stepfunctions/StepFunctionStateMachineAllLogsToCloudWatch.ts
@@ -5,27 +5,29 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnStateMachine, LogLevel } from '@aws-cdk/aws-stepfunctions';
 import { CfnResource, Stack } from '@aws-cdk/core';
-import { resolveIfPrimitive } from '../../nag-pack';
+import { resolveIfPrimitive, NagRuleCompliance } from '../../nag-pack';
 
 /**
  * Step Function log "ALL" events to CloudWatch Logs
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnStateMachine) {
       const loggingConfiguration = Stack.of(node).resolve(
         node.loggingConfiguration
       );
       if (loggingConfiguration == undefined) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
       const level = resolveIfPrimitive(node, loggingConfiguration.level);
       if (level == undefined || level != LogLevel.ALL) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/stepfunctions/StepFunctionStateMachineXray.ts
+++ b/src/rules/stepfunctions/StepFunctionStateMachineXray.ts
@@ -5,27 +5,29 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnStateMachine } from '@aws-cdk/aws-stepfunctions';
 import { CfnResource, Stack } from '@aws-cdk/core';
-import { resolveIfPrimitive } from '../../nag-pack';
+import { resolveIfPrimitive, NagRuleCompliance } from '../../nag-pack';
 
 /**
  * Step Function have X-Ray tracing enabled
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnStateMachine) {
       const tracingConfiguration = Stack.of(node).resolve(
         node.tracingConfiguration
       );
       if (tracingConfiguration == undefined) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
       const enabled = resolveIfPrimitive(node, tracingConfiguration.enabled);
       if (!enabled) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/timestream/TimestreamDatabaseCustomerManagedKey.ts
+++ b/src/rules/timestream/TimestreamDatabaseCustomerManagedKey.ts
@@ -5,19 +5,22 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnDatabase } from '@aws-cdk/aws-timestream';
 import { CfnResource } from '@aws-cdk/core';
+import { NagRuleCompliance } from '../../nag-pack';
 
 /**
  * Timestream databases use Customer Managed KMS Keys
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnDatabase) {
       if (node.kmsKeyId === undefined) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/vpc/VPCDefaultSecurityGroupClosed.ts
+++ b/src/rules/vpc/VPCDefaultSecurityGroupClosed.ts
@@ -5,6 +5,7 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnVPC } from '@aws-cdk/aws-ec2';
 import { CfnResource } from '@aws-cdk/core';
+import { NagRuleCompliance } from '../../nag-pack';
 
 /**
  * VPCs have their default security group closed
@@ -13,11 +14,12 @@ import { CfnResource } from '@aws-cdk/core';
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnVPC) {
-      return false;
+      return NagRuleCompliance.NON_COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/vpc/VPCFlowLogsEnabled.ts
+++ b/src/rules/vpc/VPCFlowLogsEnabled.ts
@@ -5,14 +5,17 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnVPC, CfnFlowLog } from '@aws-cdk/aws-ec2';
 import { CfnResource, Stack } from '@aws-cdk/core';
-import { resolveResourceFromInstrinsic } from '../../nag-pack';
+import {
+  resolveResourceFromInstrinsic,
+  NagRuleCompliance,
+} from '../../nag-pack';
 
 /**
  * VPCs have Flow Logs enabled
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnVPC) {
       const vpcLogicalId = resolveResourceFromInstrinsic(node, node.ref);
       let found = false;
@@ -25,10 +28,12 @@ export default Object.defineProperty(
         }
       }
       if (!found) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/vpc/VPCNoNACLs.ts
+++ b/src/rules/vpc/VPCNoNACLs.ts
@@ -5,17 +5,19 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnNetworkAcl, CfnNetworkAclEntry } from '@aws-cdk/aws-ec2';
 import { CfnResource } from '@aws-cdk/core';
+import { NagRuleCompliance } from '../../nag-pack';
 
 /**
  * VPCs do not implement network ACLs
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnNetworkAcl || node instanceof CfnNetworkAclEntry) {
-      return false;
+      return NagRuleCompliance.NON_COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/vpc/VPCNoUnrestrictedRouteToIGW.ts
+++ b/src/rules/vpc/VPCNoUnrestrictedRouteToIGW.ts
@@ -5,14 +5,14 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnRoute } from '@aws-cdk/aws-ec2';
 import { CfnResource } from '@aws-cdk/core';
-import { resolveIfPrimitive } from '../../nag-pack';
+import { resolveIfPrimitive, NagRuleCompliance } from '../../nag-pack';
 
 /**
  * Route tables do not have unrestricted routes ('0.0.0.0/0' or '::/0') to IGWs
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnRoute) {
       if (node.gatewayId != undefined) {
         const destinationCidrBlock = resolveIfPrimitive(
@@ -27,17 +27,19 @@ export default Object.defineProperty(
           destinationCidrBlock != undefined &&
           destinationCidrBlock.includes('/0')
         ) {
-          return false;
+          return NagRuleCompliance.NON_COMPLIANT;
         }
         if (
           destinationIpv6CidrBlock != undefined &&
           destinationIpv6CidrBlock.includes('/0')
         ) {
-          return false;
+          return NagRuleCompliance.NON_COMPLIANT;
         }
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/vpc/VPCSubnetAutoAssignPublicIpDisabled.ts
+++ b/src/rules/vpc/VPCSubnetAutoAssignPublicIpDisabled.ts
@@ -5,14 +5,14 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnSubnet } from '@aws-cdk/aws-ec2';
 import { CfnResource } from '@aws-cdk/core';
-import { resolveIfPrimitive } from '../../nag-pack';
+import { resolveIfPrimitive, NagRuleCompliance } from '../../nag-pack';
 
 /**
  * Subnets do not auto-assign public IP addresses
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnSubnet) {
       const mapPublicIpOnLaunch = resolveIfPrimitive(
         node,
@@ -26,10 +26,12 @@ export default Object.defineProperty(
         mapPublicIpOnLaunch === true ||
         assignIpv6AddressOnCreation === true
       ) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/src/rules/waf/WAFv2LoggingEnabled.ts
+++ b/src/rules/waf/WAFv2LoggingEnabled.ts
@@ -5,14 +5,17 @@ SPDX-License-Identifier: Apache-2.0
 import { parse } from 'path';
 import { CfnWebACL, CfnLoggingConfiguration } from '@aws-cdk/aws-wafv2';
 import { CfnResource, Stack } from '@aws-cdk/core';
-import { resolveResourceFromInstrinsic } from '../../nag-pack';
+import {
+  resolveResourceFromInstrinsic,
+  NagRuleCompliance,
+} from '../../nag-pack';
 
 /**
  * WAFv2 web ACLs have logging enabled
  * @param node the CfnResource to check
  */
 export default Object.defineProperty(
-  (node: CfnResource): boolean => {
+  (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnWebACL) {
       const webAclLogicalId = resolveResourceFromInstrinsic(node, node.ref);
       const webAclName = Stack.of(node).resolve(node.name);
@@ -28,10 +31,12 @@ export default Object.defineProperty(
         }
       }
       if (!found) {
-        return false;
+        return NagRuleCompliance.NON_COMPLIANT;
       }
+      return NagRuleCompliance.COMPLIANT;
+    } else {
+      return NagRuleCompliance.NOT_APPLICABLE;
     }
-    return true;
   },
   'name',
   { value: parse(__filename).name }

--- a/test/Engine.test.ts
+++ b/test/Engine.test.ts
@@ -668,7 +668,6 @@ describe('Report system', () => {
       this.lines.push(
         this.createComplianceReportLine(params, ruleId, compliance, explanation)
       );
-      this.createComplianceReportLine(params, ruleId, compliance, explanation);
       const fileName = `${this.packName}-${params.node.stack.stackName}-NagReport.csv`;
       if (!this.reportStacks.includes(fileName)) {
         this.reportStacks.push(fileName);
@@ -741,20 +740,20 @@ describe('Report system', () => {
     ];
     expect(pack.lines.sort()).toEqual(expectedOuput.sort());
   });
-  test('Suppressed error values are written properly', () => {
+  test('Suppressed error values are escaped and written properly', () => {
     const app = new App();
     const stack = new Stack(app, 'Stack1');
     const pack = new TestPack({ reports: true });
     Aspects.of(app).add(pack);
     const resource = new CfnResource(stack, 'rResource', { type: 'Error' });
     NagSuppressions.addResourceSuppressions(resource, [
-      { id: 'CdkNagValidationFailure', reason: 'lorem ipsum' },
+      { id: 'CdkNagValidationFailure', reason: '"quoted "lorem" ipsum"' },
     ]);
     app.synth();
     const expectedOuput = [
-      '"Test-Compliant","Stack1/rResource","Suppressed","lorem ipsum","Error"\n',
-      '"Test-N/A","Stack1/rResource","Suppressed","lorem ipsum","Error"\n',
-      '"Test-Non-Compliant","Stack1/rResource","Suppressed","lorem ipsum","Error"\n',
+      '"Test-Compliant","Stack1/rResource","Suppressed","""quoted ""lorem"" ipsum""","Error"\n',
+      '"Test-N/A","Stack1/rResource","Suppressed","""quoted ""lorem"" ipsum""","Error"\n',
+      '"Test-Non-Compliant","Stack1/rResource","Suppressed","""quoted ""lorem"" ipsum""","Error"\n',
     ];
     expect(pack.lines.sort()).toEqual(expectedOuput.sort());
   });

--- a/test/Engine.test.ts
+++ b/test/Engine.test.ts
@@ -696,8 +696,8 @@ describe('Report system', () => {
     new CfnResource(stack, 'rResource', { type: 'foo' });
     app.synth();
     const expectedOuput = [
-      '"Test-Compliant","Stack1/rResource","Compliant","N/A","Error"\n',
-      '"Test-Non-Compliant","Stack1/rResource","Non-Compliant","N/A","Error"\n',
+      '"Test-Compliant","Stack1/rResource","Compliant","N/A","Error","foo."\n',
+      '"Test-Non-Compliant","Stack1/rResource","Non-Compliant","N/A","Error","foo."\n',
     ];
     expect(pack.lines.sort()).toEqual(expectedOuput.sort());
   });
@@ -715,8 +715,8 @@ describe('Report system', () => {
     ]);
     app.synth();
     const expectedOuput = [
-      '"Test-Compliant","Stack1/rResource","Compliant","N/A","Error"\n',
-      '"Test-Non-Compliant","Stack1/rResource","Suppressed","lorem ipsum","Error"\n',
+      '"Test-Compliant","Stack1/rResource","Compliant","N/A","Error","foo."\n',
+      '"Test-Non-Compliant","Stack1/rResource","Suppressed","lorem ipsum","Error","foo."\n',
     ];
     expect(pack.lines.sort()).toEqual(expectedOuput.sort());
   });
@@ -734,9 +734,9 @@ describe('Report system', () => {
     ]);
     app.synth();
     const expectedOuput = [
-      '"Test-Non-Compliant","Stack1/rResource","UNKNOWN","N/A","Error"\n',
-      '"Test-Compliant","Stack1/rResource","UNKNOWN","N/A","Error"\n',
-      '"Test-N/A","Stack1/rResource","UNKNOWN","N/A","Error"\n',
+      '"Test-Non-Compliant","Stack1/rResource","UNKNOWN","N/A","Error","foo."\n',
+      '"Test-Compliant","Stack1/rResource","UNKNOWN","N/A","Error","foo."\n',
+      '"Test-N/A","Stack1/rResource","UNKNOWN","N/A","Error","foo."\n',
     ];
     expect(pack.lines.sort()).toEqual(expectedOuput.sort());
   });
@@ -751,9 +751,9 @@ describe('Report system', () => {
     ]);
     app.synth();
     const expectedOuput = [
-      '"Test-Compliant","Stack1/rResource","Suppressed","""quoted ""lorem"" ipsum""","Error"\n',
-      '"Test-N/A","Stack1/rResource","Suppressed","""quoted ""lorem"" ipsum""","Error"\n',
-      '"Test-Non-Compliant","Stack1/rResource","Suppressed","""quoted ""lorem"" ipsum""","Error"\n',
+      '"Test-Compliant","Stack1/rResource","Suppressed","""quoted ""lorem"" ipsum""","Error","foo."\n',
+      '"Test-N/A","Stack1/rResource","Suppressed","""quoted ""lorem"" ipsum""","Error","foo."\n',
+      '"Test-Non-Compliant","Stack1/rResource","Suppressed","""quoted ""lorem"" ipsum""","Error","foo."\n',
     ];
     expect(pack.lines.sort()).toEqual(expectedOuput.sort());
   });

--- a/test/Engine.test.ts
+++ b/test/Engine.test.ts
@@ -697,8 +697,8 @@ describe('Report system', () => {
     new CfnResource(stack, 'rResource', { type: 'foo' });
     app.synth();
     const expectedOuput = [
-      'Test-Compliant,Stack1/rResource,Compliant,N/A,Error\n',
-      'Test-Non-Compliant,Stack1/rResource,Non-Compliant,N/A,Error\n',
+      '"Test-Compliant","Stack1/rResource","Compliant","N/A","Error"\n',
+      '"Test-Non-Compliant","Stack1/rResource","Non-Compliant","N/A","Error"\n',
     ];
     expect(pack.lines.sort()).toEqual(expectedOuput.sort());
   });
@@ -716,8 +716,8 @@ describe('Report system', () => {
     ]);
     app.synth();
     const expectedOuput = [
-      'Test-Compliant,Stack1/rResource,Compliant,N/A,Error\n',
-      'Test-Non-Compliant,Stack1/rResource,Suppressed,lorem ipsum,Error\n',
+      '"Test-Compliant","Stack1/rResource","Compliant","N/A","Error"\n',
+      '"Test-Non-Compliant","Stack1/rResource","Suppressed","lorem ipsum","Error"\n',
     ];
     expect(pack.lines.sort()).toEqual(expectedOuput.sort());
   });
@@ -735,9 +735,9 @@ describe('Report system', () => {
     ]);
     app.synth();
     const expectedOuput = [
-      'Test-Non-Compliant,Stack1/rResource,UNKNOWN,N/A,Error\n',
-      'Test-Compliant,Stack1/rResource,UNKNOWN,N/A,Error\n',
-      'Test-N/A,Stack1/rResource,UNKNOWN,N/A,Error\n',
+      '"Test-Non-Compliant","Stack1/rResource","UNKNOWN","N/A","Error"\n',
+      '"Test-Compliant","Stack1/rResource","UNKNOWN","N/A","Error"\n',
+      '"Test-N/A","Stack1/rResource","UNKNOWN","N/A","Error"\n',
     ];
     expect(pack.lines.sort()).toEqual(expectedOuput.sort());
   });
@@ -752,9 +752,9 @@ describe('Report system', () => {
     ]);
     app.synth();
     const expectedOuput = [
-      'Test-Compliant,Stack1/rResource,Suppressed,lorem ipsum,Error\n',
-      'Test-N/A,Stack1/rResource,Suppressed,lorem ipsum,Error\n',
-      'Test-Non-Compliant,Stack1/rResource,Suppressed,lorem ipsum,Error\n',
+      '"Test-Compliant","Stack1/rResource","Suppressed","lorem ipsum","Error"\n',
+      '"Test-N/A","Stack1/rResource","Suppressed","lorem ipsum","Error"\n',
+      '"Test-Non-Compliant","Stack1/rResource","Suppressed","lorem ipsum","Error"\n',
     ];
     expect(pack.lines.sort()).toEqual(expectedOuput.sort());
   });

--- a/test/Engine.test.ts
+++ b/test/Engine.test.ts
@@ -675,11 +675,11 @@ describe('Report system', () => {
     }
   }
 
-  test('Reports are generated for all stacks', () => {
+  test('Reports are generated for all stacks by default', () => {
     const app = new App();
     const stack = new Stack(app, 'Stack1');
     const stack2 = new Stack(app, 'Stack2');
-    const pack = new TestPack({ reports: true });
+    const pack = new TestPack();
     Aspects.of(app).add(pack);
     new SecurityGroup(stack, 'rSg', {
       vpc: new Vpc(stack, 'rVpc'),
@@ -691,7 +691,7 @@ describe('Report system', () => {
   test('Compliant and Non-Compliant values are written properly', () => {
     const app = new App();
     const stack = new Stack(app, 'Stack1');
-    const pack = new TestPack({ reports: true });
+    const pack = new TestPack();
     Aspects.of(app).add(pack);
     new CfnResource(stack, 'rResource', { type: 'foo' });
     app.synth();
@@ -704,7 +704,7 @@ describe('Report system', () => {
   test('Suppression values are written properly', () => {
     const app = new App();
     const stack = new Stack(app, 'Stack1');
-    const pack = new TestPack({ reports: true });
+    const pack = new TestPack();
     Aspects.of(app).add(pack);
     const resource = new CfnResource(stack, 'rResource', { type: 'foo' });
     NagSuppressions.addResourceSuppressions(resource, [
@@ -723,7 +723,7 @@ describe('Report system', () => {
   test('Error values are written properly', () => {
     const app = new App();
     const stack = new Stack(app, 'Stack1');
-    const pack = new TestPack({ reports: true });
+    const pack = new TestPack();
     Aspects.of(app).add(pack);
     const resource = new CfnResource(stack, 'rResource', { type: 'Error' });
     NagSuppressions.addResourceSuppressions(resource, [
@@ -743,7 +743,7 @@ describe('Report system', () => {
   test('Suppressed error values are escaped and written properly', () => {
     const app = new App();
     const stack = new Stack(app, 'Stack1');
-    const pack = new TestPack({ reports: true });
+    const pack = new TestPack();
     Aspects.of(app).add(pack);
     const resource = new CfnResource(stack, 'rResource', { type: 'Error' });
     NagSuppressions.addResourceSuppressions(resource, [

--- a/test/Packs.test.ts
+++ b/test/Packs.test.ts
@@ -17,7 +17,22 @@ import {
 
 describe('Check NagPack Details', () => {
   describe('AwsSolutions', () => {
-    const pack = new AwsSolutionsChecks();
+    class AwsSolutionsChecksExtended extends AwsSolutionsChecks {
+      actualWarnings = new Array<string>();
+      actualErrors = new Array<string>();
+      applyRule(params: IApplyRule): void {
+        const ruleSuffix = params.ruleSuffixOverride
+          ? params.ruleSuffixOverride
+          : params.rule.name;
+        const ruleId = `${pack.readPackName}-${ruleSuffix}`;
+        if (params.level === NagMessageLevel.WARN) {
+          this.actualWarnings.push(ruleId);
+        } else {
+          this.actualErrors.push(ruleId);
+        }
+      }
+    }
+    const pack = new AwsSolutionsChecksExtended();
     test('Pack Name is correct', () => {
       expect(pack.readPackName).toStrictEqual('AwsSolutions');
     });
@@ -143,30 +158,32 @@ describe('Check NagPack Details', () => {
         'AwsSolutions-SQS3',
         'AwsSolutions-VPC7',
       ];
-      const actualWarnings = new Array<string>();
-      const actualErrors = new Array<string>();
-      jest.spyOn(pack, 'applyRule').mockImplementation((params: IApplyRule) => {
+      jest.spyOn(pack, 'applyRule');
+      const stack = new Stack();
+      Aspects.of(stack).add(pack);
+      new CfnResource(stack, 'rTestResource', { type: 'foo' });
+      SynthUtils.synthesize(stack).messages;
+      expect(pack.actualWarnings.sort()).toEqual(expectedWarnings.sort());
+      expect(pack.actualErrors.sort()).toEqual(expectedErrors.sort());
+    });
+  });
+  describe('HIPAA-Security', () => {
+    class HIPAASecurityChecksExtended extends HIPAASecurityChecks {
+      actualWarnings = new Array<string>();
+      actualErrors = new Array<string>();
+      applyRule(params: IApplyRule): void {
         const ruleSuffix = params.ruleSuffixOverride
           ? params.ruleSuffixOverride
           : params.rule.name;
         const ruleId = `${pack.readPackName}-${ruleSuffix}`;
         if (params.level === NagMessageLevel.WARN) {
-          actualWarnings.push(ruleId);
+          this.actualWarnings.push(ruleId);
         } else {
-          actualErrors.push(ruleId);
+          this.actualErrors.push(ruleId);
         }
-        return ruleId;
-      });
-      const stack = new Stack();
-      Aspects.of(stack).add(pack);
-      new CfnResource(stack, 'rTestResource', { type: 'foo' });
-      SynthUtils.synthesize(stack).messages;
-      expect(actualWarnings.sort()).toEqual(expectedWarnings.sort());
-      expect(actualErrors.sort()).toEqual(expectedErrors.sort());
-    });
-  });
-  describe('HIPAA-Security', () => {
-    const pack = new HIPAASecurityChecks();
+      }
+    }
+    const pack = new HIPAASecurityChecksExtended();
     test('Pack Name is correct', () => {
       expect(pack.readPackName).toStrictEqual('HIPAA.Security');
     });
@@ -261,30 +278,32 @@ describe('Check NagPack Details', () => {
         'HIPAA.Security-VPCSubnetAutoAssignPublicIpDisabled',
         'HIPAA.Security-WAFv2LoggingEnabled',
       ];
-      const actualWarnings = new Array<string>();
-      const actualErrors = new Array<string>();
-      jest.spyOn(pack, 'applyRule').mockImplementation((params: IApplyRule) => {
+      jest.spyOn(pack, 'applyRule');
+      const stack = new Stack();
+      Aspects.of(stack).add(pack);
+      new CfnResource(stack, 'rTestResource', { type: 'foo' });
+      SynthUtils.synthesize(stack).messages;
+      expect(pack.actualWarnings.sort()).toEqual(expectedWarnings.sort());
+      expect(pack.actualErrors.sort()).toEqual(expectedErrors.sort());
+    });
+  });
+  describe('NIST-800-53-R4', () => {
+    class NIST80053R4ChecksExtended extends NIST80053R4Checks {
+      actualWarnings = new Array<string>();
+      actualErrors = new Array<string>();
+      applyRule(params: IApplyRule): void {
         const ruleSuffix = params.ruleSuffixOverride
           ? params.ruleSuffixOverride
           : params.rule.name;
         const ruleId = `${pack.readPackName}-${ruleSuffix}`;
         if (params.level === NagMessageLevel.WARN) {
-          actualWarnings.push(ruleId);
+          this.actualWarnings.push(ruleId);
         } else {
-          actualErrors.push(ruleId);
+          this.actualErrors.push(ruleId);
         }
-        return ruleId;
-      });
-      const stack = new Stack();
-      Aspects.of(stack).add(pack);
-      new CfnResource(stack, 'rTestResource', { type: 'foo' });
-      SynthUtils.synthesize(stack).messages;
-      expect(actualWarnings.sort()).toEqual(expectedWarnings.sort());
-      expect(actualErrors.sort()).toEqual(expectedErrors.sort());
-    });
-  });
-  describe('NIST-800-53-R4', () => {
-    const pack = new NIST80053R4Checks();
+      }
+    }
+    const pack = new NIST80053R4ChecksExtended();
     test('Pack Name is correct', () => {
       expect(pack.readPackName).toStrictEqual('NIST.800.53.R4');
     });
@@ -359,30 +378,32 @@ describe('Check NagPack Details', () => {
         'NIST.800.53.R4-VPCFlowLogsEnabled',
         'NIST.800.53.R4-WAFv2LoggingEnabled',
       ];
-      const actualWarnings = new Array<string>();
-      const actualErrors = new Array<string>();
-      jest.spyOn(pack, 'applyRule').mockImplementation((params: IApplyRule) => {
+      jest.spyOn(pack, 'applyRule');
+      const stack = new Stack();
+      Aspects.of(stack).add(pack);
+      new CfnResource(stack, 'rTestResource', { type: 'foo' });
+      SynthUtils.synthesize(stack).messages;
+      expect(pack.actualWarnings.sort()).toEqual(expectedWarnings.sort());
+      expect(pack.actualErrors.sort()).toEqual(expectedErrors.sort());
+    });
+  });
+  describe('NIST-800-53-R5', () => {
+    class NIST80053R5ChecksExtended extends NIST80053R5Checks {
+      actualWarnings = new Array<string>();
+      actualErrors = new Array<string>();
+      applyRule(params: IApplyRule): void {
         const ruleSuffix = params.ruleSuffixOverride
           ? params.ruleSuffixOverride
           : params.rule.name;
         const ruleId = `${pack.readPackName}-${ruleSuffix}`;
         if (params.level === NagMessageLevel.WARN) {
-          actualWarnings.push(ruleId);
+          this.actualWarnings.push(ruleId);
         } else {
-          actualErrors.push(ruleId);
+          this.actualErrors.push(ruleId);
         }
-        return ruleId;
-      });
-      const stack = new Stack();
-      Aspects.of(stack).add(pack);
-      new CfnResource(stack, 'rTestResource', { type: 'foo' });
-      SynthUtils.synthesize(stack).messages;
-      expect(actualWarnings.sort()).toEqual(expectedWarnings.sort());
-      expect(actualErrors.sort()).toEqual(expectedErrors.sort());
-    });
-  });
-  describe('NIST-800-53-R5', () => {
-    const pack = new NIST80053R5Checks();
+      }
+    }
+    const pack = new NIST80053R5ChecksExtended();
     test('Pack Name is correct', () => {
       expect(pack.readPackName).toStrictEqual('NIST.800.53.R5');
     });
@@ -472,30 +493,32 @@ describe('Check NagPack Details', () => {
         'NIST.800.53.R5-VPCSubnetAutoAssignPublicIpDisabled',
         'NIST.800.53.R5-WAFv2LoggingEnabled',
       ];
-      const actualWarnings = new Array<string>();
-      const actualErrors = new Array<string>();
-      jest.spyOn(pack, 'applyRule').mockImplementation((params: IApplyRule) => {
+      jest.spyOn(pack, 'applyRule');
+      const stack = new Stack();
+      Aspects.of(stack).add(pack);
+      new CfnResource(stack, 'rTestResource', { type: 'foo' });
+      SynthUtils.synthesize(stack).messages;
+      expect(pack.actualWarnings.sort()).toEqual(expectedWarnings.sort());
+      expect(pack.actualErrors.sort()).toEqual(expectedErrors.sort());
+    });
+  });
+  describe('PCI-DSS-3.2.1', () => {
+    class PCIDSS321ChecksExtended extends PCIDSS321Checks {
+      actualWarnings = new Array<string>();
+      actualErrors = new Array<string>();
+      applyRule(params: IApplyRule): void {
         const ruleSuffix = params.ruleSuffixOverride
           ? params.ruleSuffixOverride
           : params.rule.name;
         const ruleId = `${pack.readPackName}-${ruleSuffix}`;
         if (params.level === NagMessageLevel.WARN) {
-          actualWarnings.push(ruleId);
+          this.actualWarnings.push(ruleId);
         } else {
-          actualErrors.push(ruleId);
+          this.actualErrors.push(ruleId);
         }
-        return ruleId;
-      });
-      const stack = new Stack();
-      Aspects.of(stack).add(pack);
-      new CfnResource(stack, 'rTestResource', { type: 'foo' });
-      SynthUtils.synthesize(stack).messages;
-      expect(actualWarnings.sort()).toEqual(expectedWarnings.sort());
-      expect(actualErrors.sort()).toEqual(expectedErrors.sort());
-    });
-  });
-  describe('PCI-DSS-3.2.1', () => {
-    const pack = new PCIDSS321Checks();
+      }
+    }
+    const pack = new PCIDSS321ChecksExtended();
     test('Pack Name is correct', () => {
       expect(pack.readPackName).toStrictEqual('PCI.DSS.321');
     });
@@ -570,26 +593,13 @@ describe('Check NagPack Details', () => {
         'PCI.DSS.321-VPCSubnetAutoAssignPublicIpDisabled',
         'PCI.DSS.321-WAFv2LoggingEnabled',
       ];
-      const actualWarnings = new Array<string>();
-      const actualErrors = new Array<string>();
-      jest.spyOn(pack, 'applyRule').mockImplementation((params: IApplyRule) => {
-        const ruleSuffix = params.ruleSuffixOverride
-          ? params.ruleSuffixOverride
-          : params.rule.name;
-        const ruleId = `${pack.readPackName}-${ruleSuffix}`;
-        if (params.level === NagMessageLevel.WARN) {
-          actualWarnings.push(ruleId);
-        } else {
-          actualErrors.push(ruleId);
-        }
-        return ruleId;
-      });
+      jest.spyOn(pack, 'applyRule');
       const stack = new Stack();
       Aspects.of(stack).add(pack);
       new CfnResource(stack, 'rTestResource', { type: 'foo' });
       SynthUtils.synthesize(stack).messages;
-      expect(actualWarnings.sort()).toEqual(expectedWarnings.sort());
-      expect(actualErrors.sort()).toEqual(expectedErrors.sort());
+      expect(pack.actualWarnings.sort()).toEqual(expectedWarnings.sort());
+      expect(pack.actualErrors.sort()).toEqual(expectedErrors.sort());
     });
   });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -5067,12 +5067,7 @@ json-schema-traverse@^1.0.0:
   resolved "https://registry.yarnpkg.com/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz#ae7bcb3656ab77a73ba5c49bf654f38e6b6860e2"
   integrity sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==
 
-json-schema@0.2.3:
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.2.3.tgz#b480c892e59a2f05954ce727bd3f2a4e882f9e13"
-  integrity sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=
-
-json-schema@^0.4.0:
+json-schema@0.2.3, json-schema@^0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/json-schema/-/json-schema-0.4.0.tgz#f7de4cf6efab838ebaeb3236474cbba5a1930ab5"
   integrity sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==


### PR DESCRIPTION
This PR adds a feature to optionally generate csv compliance reports for applied packs. For example

```typescript
import { App, Aspects } from '@aws-cdk/core';
import { CdkTestStack } from '../lib/cdk-test-stack';
import { AwsSolutionsChecks } from 'cdk-nag';

const app = new App();
new CdkTestStack(app, 'FancyStack');
// Reports on by default
Aspects.of(app).add(new AwsSolutionsChecks());
//Aspects.of(app).add(new AwsSolutionsChecks({reports: false}));
```

A report could look like the following `AwsSolutions-FancyStack-NagReport.csv`

```csv
Rule ID,Resource ID,Compliance,Exception Reason,Rule Level, Rule Info
"AwsSolutions-VPC7","FancyStack/rVpc/Resource","Non-Compliant","N/A","Error","Insert Info here"
"AwsSolutions-EC23","FancyStack/rSg/Resource","Suppressed","a really great reason","Error","Insert Info here"
"AwsSolutions-EC27","FancyStack/rSg/Resource","Compliant","N/A,Error","Insert Info here"
```

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*