### PR TITLE
feat: export rules as package

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -9,3 +9,4 @@ export * from './packs/nist-800-53-r5';
 export * from './packs/pci-dss-321';
 export * from './nag-pack';
 export * from './nag-suppressions';
+export * as rules from './rules';

--- a/src/rules/index.ts
+++ b/src/rules/index.ts
@@ -1,0 +1,45 @@
+/*
+Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+SPDX-License-Identifier: Apache-2.0
+*/
+export * as apigw from './apigw';
+export * as appsync from './appsync';
+export * as athena from './athena';
+export * as autoscaling from './autoscaling';
+export * as cloud9 from './cloud9';
+export * as cloudfront from './cloudfront';
+export * as cloudtrail from './cloudtrail';
+export * as cloudwatch from './cloudwatch';
+export * as codebuild from './codebuild';
+export * as cognito from './cognito';
+export * as dms from './dms';
+export * as documentdb from './documentdb';
+export * as dynamodb from './dynamodb';
+export * as ec2 from './ec2';
+export * as ecr from './ecr';
+export * as ecs from './ecs';
+export * as efs from './efs';
+export * as elasticache from './elasticache';
+export * as elasticbeanstalk from './elasticbeanstalk';
+export * as elb from './elb';
+export * as emr from './emr';
+export * as iam from './iam';
+export * as kinesis from './kinesis';
+export * as kms from './kms';
+export * as lambda from './lambda';
+export * as mediastore from './mediastore';
+export * as msk from './msk';
+export * as neptune from './neptune';
+export * as opensearch from './opensearch';
+export * as quicksight from './quicksight';
+export * as rds from './rds';
+export * as redshift from './redshift';
+export * as s3 from './s3';
+export * as sagemaker from './sagemaker';
+export * as secretsmanager from './secretsmanager';
+export * as sns from './sns';
+export * as sqs from './sqs';
+export * as stepfunctions from './stepfunctions';
+export * as timestream from './timestream';
+export * as vpc from './vpc';
+export * as waf from './waf';


### PR DESCRIPTION
Related to #482 

Examples for rule imports
```typescript
import { apigw } from 'cdk-nag/lib/rules'
import { rules } from 'cdk-nag';
rules.apigw.APIGWAccessLogging
apigw.APIGWAccessLogging
```

Example for creating a NagPack with an included rule
```typescript
import { Stack, App, StackProps, IConstruct, CfnResource, Aspects } from '@aws-cdk/core';
import { Vpc } from '@aws-cdk/aws-ec2';
import { NagMessageLevel, NagPack, NagPackProps, rules } from 'cdk-nag';


class TestPack extends NagPack {
    constructor(props?: NagPackProps) {
        super(props);
        this.packName = 'Test';
    }
    public visit(node: IConstruct): void {
        if (node instanceof CfnResource) {
            this.applyRule({
                info: 'My brief info.',
                explanation: 'My detailed explanation.',
                level: NagMessageLevel.ERROR,
                rule: rules.vpc.VPCDefaultSecurityGroupClosed,
                node: node,
            });
        }
    }
}
export class CdkTestStack extends Stack {
    constructor(scope: App, id: string, props?: StackProps) {
        super(scope, id, props);
        Aspects.of(this).add(new TestPack())
        new Vpc(this, 'rVpc')
    }
}


```

----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*