### PR TITLE
feat: addResourceSuppressionsByPath throws error when resource is not found.

### DIFF
--- a/src/nag-suppressions.ts
+++ b/src/nag-suppressions.ts
@@ -84,6 +84,7 @@ export class NagSuppressions {
     suppressions: NagPackSuppression[],
     applyToChildren: boolean = false
   ): void {
+    let added = false;
     for (const child of stack.node.findAll()) {
       const fixedPath = path.replace(/^\//, '');
       if (
@@ -95,7 +96,13 @@ export class NagSuppressions {
           suppressions,
           applyToChildren
         );
+        added = true;
       }
+    }
+    if (!added) {
+      throw new Error(
+        `Suppression path "${path}" did not match any resource. This can occur when a resource does not exist or if a suppression is applied before a resource is created.`
+      );
     }
   }
 }

--- a/test/Engine.test.ts
+++ b/test/Engine.test.ts
@@ -736,6 +736,20 @@ describe('Rule suppression system', () => {
       })
     );
   });
+
+  test('Test path miss', () => {
+    const stack = new Stack();
+    try {
+      NagSuppressions.addResourceSuppressionsByPath(stack, '/No/Such/Path', [
+        { id: 'NA', reason: '............' },
+      ]);
+      throw new Error('Did not fail');
+    } catch (err) {
+      expect(err + '').toBe(
+        `Error: Suppression path "/No/Such/Path" did not match any resource. This can occur when a resource does not exist or if a suppression is applied before a resource is created.`
+      );
+    }
+  });
 });
 
 describe('Rule explanations', () => {


### PR DESCRIPTION
Related to #800

When calling addResourceSuppressionsByPath, if no resource is found an error is thrown. Calling addResourceSuppressionsByPath and not finding a resource could indicate a problem in the code, and could lead to future unintended suppressions.


----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*
