### PR TITLE
chore: revert "feat: Go support (#986)" for failing release workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -174,28 +174,3 @@ jobs:
         run: cd .repo && npx projen package:dotnet
       - name: Collect dotnet Artifact
         run: mv .repo/dist dist
-  package-go:
-    needs: build
-    runs-on: ubuntu-latest
-    permissions: {}
-    if: "! needs.build.outputs.self_mutation_happened"
-    steps:
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 14.x
-      - uses: actions/setup-go@v3
-        with:
-          go-version: ^1.16.0
-      - name: Download build artifacts
-        uses: actions/download-artifact@v3
-        with:
-          name: build-artifact
-          path: dist
-      - name: Prepare Repository
-        run: mv dist .repo
-      - name: Install Dependencies
-        run: cd .repo && yarn install --check-files --frozen-lockfile
-      - name: Create go artifact
-        run: cd .repo && npx projen package:go
-      - name: Collect go Artifact
-        run: mv .repo/dist dist

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -195,36 +195,3 @@ jobs:
         run: npx -p publib@latest publib-nuget
         env:
           NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
-  release_golang:
-    name: Publish to GitHub Go Module Repository
-    needs: release
-    runs-on: ubuntu-latest
-    permissions:
-      contents: read
-    if: needs.release.outputs.latest_commit == github.sha
-    steps:
-      - uses: actions/setup-node@v3
-        with:
-          node-version: 14.x
-      - uses: actions/setup-go@v3
-        with:
-          go-version: ^1.16.0
-      - name: Download build artifacts
-        uses: actions/download-artifact@v3
-        with:
-          name: build-artifact
-          path: dist
-      - name: Prepare Repository
-        run: mv dist .repo
-      - name: Install Dependencies
-        run: cd .repo && yarn install --check-files --frozen-lockfile
-      - name: Create go artifact
-        run: cd .repo && npx projen package:go
-      - name: Collect go Artifact
-        run: mv .repo/dist dist
-      - name: Release
-        run: npx -p publib@latest publib-golang
-        env:
-          GIT_USER_NAME: github-actions
-          GIT_USER_EMAIL: github-actions@github.com
-          GITHUB_TOKEN: ${{ secrets.GO_GITHUB_TOKEN }}

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -10,7 +10,6 @@ queue_rules:
       - status-success=package-java
       - status-success=package-python
       - status-success=package-dotnet
-      - status-success=package-go
 pull_request_rules:
   - name: Automatic merge on approval and successful build
     actions:
@@ -30,4 +29,3 @@ pull_request_rules:
       - status-success=package-java
       - status-success=package-python
       - status-success=package-dotnet
-      - status-success=package-go

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -154,9 +154,6 @@
         },
         {
           "spawn": "package:dotnet"
-        },
-        {
-          "spawn": "package:go"
         }
       ]
     },
@@ -166,15 +163,6 @@
       "steps": [
         {
           "exec": "jsii-pacmak -v --target dotnet"
-        }
-      ]
-    },
-    "package:go": {
-      "name": "package:go",
-      "description": "Create go language bindings",
-      "steps": [
-        {
-          "exec": "jsii-pacmak -v --target go"
         }
       ]
     },

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -29,9 +29,6 @@ const project = new awscdk.AwsCdkConstructLibrary({
     mavenArtifactId: 'cdknag',
     mavenEndpoint: 'https://s01.oss.sonatype.org',
   },
-  publishToGo: {
-    moduleName: 'github.com/cdklabs/cdk-nag-go',
-  },
   projenUpgradeSecret: 'PROJEN_GITHUB_TOKEN',
   autoApproveOptions: {
     allowedUsernames: ['cdklabs-automation'],

--- a/README.md
+++ b/README.md
@@ -9,15 +9,12 @@ SPDX-License-Identifier: Apache-2.0
 [![npm version](https://img.shields.io/npm/v/cdk-nag)](https://www.npmjs.com/package/cdk-nag)
 [![Maven version](https://img.shields.io/maven-central/v/io.github.cdklabs/cdknag)](https://search.maven.org/search?q=a:cdknag)
 [![NuGet version](https://img.shields.io/nuget/v/Cdklabs.CdkNag)](https://www.nuget.org/packages/Cdklabs.CdkNag)
-[![Go version](https://img.shields.io/github/go-mod/go-version/cdklabs/cdk-nag-go?color=blue&filename=cdknag%2Fgo.mod)](https://github.com/cdklabs/cdk-nag-go)
-
-[![View on Construct Hub](https://constructs.dev/badge?package=cdk-nag)](https://constructs.dev/packages/cdk-nag)
 
 Check CDK applications or [CloudFormation templates](#using-on-cloudformation-templates) for best practices using a combination of available rule packs. Inspired by [cfn_nag](https://github.com/stelligent/cfn_nag).
 
 Check out [this blog post](https://aws.amazon.com/blogs/devops/manage-application-security-and-compliance-with-the-aws-cloud-development-kit-and-cdk-nag/) for a guided overview!
 
-![demo](cdk_nag.gif)
+![](cdk_nag.gif)
 
 ## Available Packs
 
@@ -264,6 +261,7 @@ You would see the following error on synth/deploy
 
 ## Suppressing `aws-cdk-lib/pipelines` Violations
 
+
 The [aws-cdk-lib/pipelines.CodePipeline](https://docs.aws.amazon.com/cdk/api/v2/docs/aws-cdk-lib.pipelines.CodePipeline.html) construct and its child constructs are not guaranteed to be "Visited" by `Aspects`, as they are not added during the "Construction" phase of the [cdk lifecycle](https://docs.aws.amazon.com/cdk/v2/guide/apps.html#lifecycle). Because of this behavior, you may experience problems such as rule violations not appearing or the inability to suppress violations on these constructs.
 
 You can remediate these rule violation and suppression problems by forcing the pipeline construct creation forward by calling `.buildPipeline()` on your `CodePipeline` object. Otherwise you may see errors such as:
@@ -288,12 +286,11 @@ const app = new App();
 new ExamplePipeline(app, 'example-cdk-pipeline');
 Aspects.of(app).add(new AwsSolutionsChecks({ verbose: true }));
 app.synth();
-
-````
-
-`example-pipeline.ts`
-
-```ts
+  ```
+  
+  `example-pipeline.ts`
+  
+  ```ts
 import { Stack, StackProps } from 'aws-cdk-lib';
 import { Repository } from 'aws-cdk-lib/aws-codecommit';
 import { CodePipeline, CodePipelineSource, ShellStep } from 'aws-cdk-lib/pipelines';
@@ -301,33 +298,32 @@ import { NagSuppressions } from 'cdk-nag';
 import { Construct } from 'constructs';
 
 export class ExamplePipeline extends Stack {
-constructor(scope: Construct, id: string, props?: StackProps) {
-  super(scope, id, props);
+  constructor(scope: Construct, id: string, props?: StackProps) {
+    super(scope, id, props);
 
-  const exampleSynth = new ShellStep('ExampleSynth', {
-    commands: ['yarn build --frozen-lockfile'],
-    input: CodePipelineSource.codeCommit(new Repository(this, 'ExampleRepo', { repositoryName: 'ExampleRepo' }), 'main'),
-  });
+    const exampleSynth = new ShellStep('ExampleSynth', {
+      commands: ['yarn build --frozen-lockfile'],
+      input: CodePipelineSource.codeCommit(new Repository(this, 'ExampleRepo', { repositoryName: 'ExampleRepo' }), 'main'),
+    });
 
-  const ExamplePipeline = new CodePipeline(this, 'ExamplePipeline', {
-    synth: exampleSynth,
-  });
+    const ExamplePipeline = new CodePipeline(this, 'ExamplePipeline', {
+      synth: exampleSynth,
+    });
 
-  // Force the pipeline construct creation forward before applying suppressions.
-  // @See https://github.com/aws/aws-cdk/issues/18440
-  ExamplePipeline.buildPipeline();
+    // Force the pipeline construct creation forward before applying suppressions.
+    // @See https://github.com/aws/aws-cdk/issues/18440
+    ExamplePipeline.buildPipeline();
 
-  // The path suppression will error if you comment out "ExamplePipeline.buildPipeline();""
-  NagSuppressions.addResourceSuppressionsByPath(this, '/example-cdk-pipeline/ExamplePipeline/Pipeline/ArtifactsBucket/Resource', [
-    {
-      id: 'AwsSolutions-S1',
-      reason: 'Because I said so',
-    },
-  ]);
+    // The path suppression will error if you comment out "ExamplePipeline.buildPipeline();""
+    NagSuppressions.addResourceSuppressionsByPath(this, '/example-cdk-pipeline/ExamplePipeline/Pipeline/ArtifactsBucket/Resource', [
+      {
+        id: 'AwsSolutions-S1',
+        reason: 'Because I said so',
+      },
+    ]);
+  }
 }
-}
-````
-
+  ```
 </details>
 
 ## Rules and Property Overrides

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "package": "npx projen package",
     "package-all": "npx projen package-all",
     "package:dotnet": "npx projen package:dotnet",
-    "package:go": "npx projen package:go",
     "package:java": "npx projen package:java",
     "package:js": "npx projen package:js",
     "package:python": "npx projen package:python",
@@ -136,9 +135,6 @@
       "dotnet": {
         "namespace": "Cdklabs.CdkNag",
         "packageId": "Cdklabs.CdkNag"
-      },
-      "go": {
-        "moduleName": "github.com/cdklabs/cdk-nag-go"
       }
     },
     "tsc": {


### PR DESCRIPTION
This reverts commit 948201f370f4c966968db2d911ab5f71b65ae4a8.

## Summary

This [PR](https://github.com/cdklabs/cdk-nag/pull/986) introduced a failing step in the release [workflow](https://github.com/cdklabs/cdk-nag/runs/7988167915?check_suite_focus=true). The failing step was for publishing to GitHub's Go Module repo but was failing due to a permission error. These failures should be resolved before merging into the main branch.