### PR TITLE
feat: Add metadata to reports

### DIFF
--- a/API.md
+++ b/API.md
@@ -286,18 +286,19 @@ protected createComplianceReportLine(params: IApplyRule, ruleId: string, complia
 __Returns__:
 * <code>string</code>
 
-#### protected createMessage(ruleId, findingId, info, explanation) <a id="cdk-nag-nagpack-createmessage"></a>
+#### protected createMessage(ruleId, findingId, info, explanation, metadata?) <a id="cdk-nag-nagpack-createmessage"></a>
 
 The message to output to the console when a rule is triggered.
 
 ```ts
-protected createMessage(ruleId: string, findingId: string, info: string, explanation: string): string
+protected createMessage(ruleId: string, findingId: string, info: string, explanation: string, metadata?: string): string
 ```
 
 * **ruleId** (<code>string</code>)  The id of the rule.
 * **findingId** (<code>string</code>)  The id of the finding.
 * **info** (<code>string</code>)  Why the rule was triggered.
 * **explanation** (<code>string</code>)  Why the rule exists.
+* **metadata** (<code>string</code>)  custom metadata for the rule.
 
 __Returns__:
 * <code>string</code>

--- a/API.md
+++ b/API.md
@@ -520,6 +520,7 @@ Name | Type | Description
 **info** | <code>string</code> | Why the rule was triggered.
 **level** | <code>[NagMessageLevel](#cdk-nag-nagmessagelevel)</code> | The annotations message level to apply to the rule if triggered.
 **node** | <code>[CfnResource](#aws-cdk-lib-cfnresource)</code> | Ignores listed in cdk-nag metadata.
+**metadata**? | <code>string</code> | Custom metadata to include in reports.<br/>__*Optional*__
 **ruleSuffixOverride**? | <code>string</code> | Override for the suffix of the Rule ID for this rule.<br/>__*Optional*__
 
 ### Methods

--- a/src/nag-pack.ts
+++ b/src/nag-pack.ts
@@ -42,6 +42,10 @@ export interface IApplyRule {
    */
   ruleSuffixOverride?: string;
   /**
+   * Custom metadata to include in reports.
+   */
+  metadata?: string;
+  /**
    * Why the rule was triggered.
    */
   info: string;
@@ -289,7 +293,7 @@ export abstract class NagPack implements IAspect {
       this.reportStacks.push(fileName);
       writeFileSync(
         filePath,
-        'Rule ID,Resource ID,Compliance,Exception Reason,Rule Level,Rule Info\n'
+        'Rule ID,Resource ID,Compliance,Exception Reason,Rule Level,Rule Info,Metadata\n'
       );
     }
   }
@@ -327,6 +331,7 @@ export abstract class NagPack implements IAspect {
     }
     line.push(params.level);
     line.push(params.info);
+    line.push(params.metadata ?? 'N/A');
     return line.map((i) => '"' + i.replace(/"/g, '""') + '"').join(',') + '\n';
   }
 

--- a/src/nag-pack.ts
+++ b/src/nag-pack.ts
@@ -155,7 +155,8 @@ export abstract class NagPack implements IAspect {
                 SUPPRESSION_ID,
                 findingId,
                 `${ruleId} was triggered but suppressed.`,
-                `Provided reason: "${suppressionReason}"`
+                `Provided reason: "${suppressionReason}"`,
+                params.metadata
               );
               Annotations.of(params.node).addInfo(message);
             }
@@ -164,7 +165,8 @@ export abstract class NagPack implements IAspect {
               ruleId,
               findingId,
               params.info,
-              params.explanation
+              params.explanation,
+              params.metadata
             );
             if (params.level == NagMessageLevel.ERROR) {
               Annotations.of(params.node).addError(message);
@@ -185,7 +187,8 @@ export abstract class NagPack implements IAspect {
             SUPPRESSION_ID,
             '',
             `${VALIDATION_FAILURE_ID} was triggered but suppressed.`,
-            reason
+            reason,
+            params.metadata
           );
           Annotations.of(params.node).addInfo(message);
         }
@@ -195,7 +198,8 @@ export abstract class NagPack implements IAspect {
           VALIDATION_FAILURE_ID,
           '',
           information,
-          (error as Error).message
+          (error as Error).message,
+          params.metadata
         );
         Annotations.of(params.node).addWarning(message);
       }
@@ -233,18 +237,22 @@ export abstract class NagPack implements IAspect {
    * @param findingId The id of the finding.
    * @param info Why the rule was triggered.
    * @param explanation Why the rule exists.
+   * @param metadata custom metadata for the rule.
    * @returns The formatted message string.
    */
   protected createMessage(
     ruleId: string,
     findingId: string,
     info: string,
-    explanation: string
+    explanation: string,
+    metadata: string = ''
   ): string {
     let message = findingId
       ? `${ruleId}[${findingId}]: ${info}`
       : `${ruleId}: ${info}`;
-    return this.verbose ? `${message} ${explanation}\n` : `${message}\n`;
+    return this.verbose
+      ? `${message} ${explanation} ${metadata}\n`
+      : `${message}\n`;
   }
 
   /**

--- a/test/Engine.test.ts
+++ b/test/Engine.test.ts
@@ -980,6 +980,17 @@ describe('Report system', () => {
     }
   }
 
+  class MetadataTestPack extends TestPack {
+    constructor(props?: NagPackProps) {
+      super(props);
+      this.packName = 'MetadataTest';
+    }
+
+    protected applyRule(params: IApplyRule) {
+      super.applyRule({ ...params, metadata: 'Test' });
+    }
+  }
+
   test('Reports are generated for all stacks by default', () => {
     const app = new App();
     const stack = new Stack(app, 'Stack1');
@@ -1026,8 +1037,8 @@ describe('Report system', () => {
     new CfnResource(stack, 'rResource', { type: 'foo' });
     app.synth();
     const expectedOuput = [
-      '"Test-Compliant","Stack1/rResource","Compliant","N/A","Error","foo."\n',
-      '"Test-Non-Compliant","Stack1/rResource","Non-Compliant","N/A","Error","foo."\n',
+      '"Test-Compliant","Stack1/rResource","Compliant","N/A","Error","foo.","N/A"\n',
+      '"Test-Non-Compliant","Stack1/rResource","Non-Compliant","N/A","Error","foo.","N/A"\n',
     ];
     expect(pack.lines.sort()).toEqual(expectedOuput.sort());
   });
@@ -1045,8 +1056,8 @@ describe('Report system', () => {
     ]);
     app.synth();
     const expectedOuput = [
-      '"Test-Compliant","Stack1/rResource","Compliant","N/A","Error","foo."\n',
-      '"Test-Non-Compliant","Stack1/rResource","Suppressed","lorem ipsum","Error","foo."\n',
+      '"Test-Compliant","Stack1/rResource","Compliant","N/A","Error","foo.","N/A"\n',
+      '"Test-Non-Compliant","Stack1/rResource","Suppressed","lorem ipsum","Error","foo.","N/A"\n',
     ];
     expect(pack.lines.sort()).toEqual(expectedOuput.sort());
   });
@@ -1064,8 +1075,8 @@ describe('Report system', () => {
     ]);
     app.synth();
     const expectedOuput = [
-      '"Test-Compliant","Stack1/rResource","Compliant","N/A","Error","foo."\n',
-      '"Test-Non-Compliant","Stack1/rResource","Suppressed","あいうえおかきくけこ","Error","foo."\n',
+      '"Test-Compliant","Stack1/rResource","Compliant","N/A","Error","foo.","N/A"\n',
+      '"Test-Non-Compliant","Stack1/rResource","Suppressed","あいうえおかきくけこ","Error","foo.","N/A"\n',
     ];
     expect(pack.lines.sort()).toEqual(expectedOuput.sort());
   });
@@ -1083,9 +1094,9 @@ describe('Report system', () => {
     ]);
     app.synth();
     const expectedOuput = [
-      '"Test-Non-Compliant","Stack1/rResource","UNKNOWN","N/A","Error","foo."\n',
-      '"Test-Compliant","Stack1/rResource","UNKNOWN","N/A","Error","foo."\n',
-      '"Test-N/A","Stack1/rResource","UNKNOWN","N/A","Error","foo."\n',
+      '"Test-Non-Compliant","Stack1/rResource","UNKNOWN","N/A","Error","foo.","N/A"\n',
+      '"Test-Compliant","Stack1/rResource","UNKNOWN","N/A","Error","foo.","N/A"\n',
+      '"Test-N/A","Stack1/rResource","UNKNOWN","N/A","Error","foo.","N/A"\n',
     ];
     expect(pack.lines.sort()).toEqual(expectedOuput.sort());
   });
@@ -1100,9 +1111,22 @@ describe('Report system', () => {
     ]);
     app.synth();
     const expectedOuput = [
-      '"Test-Compliant","Stack1/rResource","Suppressed","""quoted ""lorem"" ipsum""","Error","foo."\n',
-      '"Test-N/A","Stack1/rResource","Suppressed","""quoted ""lorem"" ipsum""","Error","foo."\n',
-      '"Test-Non-Compliant","Stack1/rResource","Suppressed","""quoted ""lorem"" ipsum""","Error","foo."\n',
+      '"Test-Compliant","Stack1/rResource","Suppressed","""quoted ""lorem"" ipsum""","Error","foo.","N/A"\n',
+      '"Test-N/A","Stack1/rResource","Suppressed","""quoted ""lorem"" ipsum""","Error","foo.","N/A"\n',
+      '"Test-Non-Compliant","Stack1/rResource","Suppressed","""quoted ""lorem"" ipsum""","Error","foo.","N/A"\n',
+    ];
+    expect(pack.lines.sort()).toEqual(expectedOuput.sort());
+  });
+  test('Metadata emitted properly', () => {
+    const app = new App();
+    const stack = new Stack(app, 'Stack1');
+    const pack = new MetadataTestPack();
+    Aspects.of(app).add(pack);
+    new CfnResource(stack, 'rResource', { type: 'foo' });
+    app.synth();
+    const expectedOuput = [
+      '"MetadataTest-Compliant","Stack1/rResource","Compliant","N/A","Error","foo.","Test"\n',
+      '"MetadataTest-Non-Compliant","Stack1/rResource","Non-Compliant","N/A","Error","foo.","Test"\n',
     ];
     expect(pack.lines.sort()).toEqual(expectedOuput.sort());
   });


### PR DESCRIPTION
Allow rules to specify arbitrary metadata to be included in generated reports.

This is an extension point to allow rule authors to be able to add additional metadata to rules that are triggered. Examples of this include custom categorisations i.e: Severity.

Overloading explanation or info doesn't seem like the right place for these types of dimensions and thought it would be better to include a new "catch-all" field for these purposes.