### PR TITLE
feat(nag-logger): provide loggers with original rule name

### DIFF
--- a/API.md
+++ b/API.md
@@ -110,6 +110,7 @@ onCompliance(_data: NagLoggerComplianceData): void
   * **ruleId** (<code>string</code>)  *No description* 
   * **ruleInfo** (<code>string</code>)  *No description* 
   * **ruleLevel** (<code>[NagMessageLevel](#cdk-nag-nagmessagelevel)</code>)  *No description* 
+  * **ruleOriginalName** (<code>string</code>)  *No description* 
 
 
 
@@ -129,6 +130,7 @@ onError(data: NagLoggerErrorData): void
   * **ruleId** (<code>string</code>)  *No description* 
   * **ruleInfo** (<code>string</code>)  *No description* 
   * **ruleLevel** (<code>[NagMessageLevel](#cdk-nag-nagmessagelevel)</code>)  *No description* 
+  * **ruleOriginalName** (<code>string</code>)  *No description* 
   * **errorMessage** (<code>string</code>)  *No description* 
 
 
@@ -149,6 +151,7 @@ onNonCompliance(data: NagLoggerNonComplianceData): void
   * **ruleId** (<code>string</code>)  *No description* 
   * **ruleInfo** (<code>string</code>)  *No description* 
   * **ruleLevel** (<code>[NagMessageLevel](#cdk-nag-nagmessagelevel)</code>)  *No description* 
+  * **ruleOriginalName** (<code>string</code>)  *No description* 
   * **findingId** (<code>string</code>)  *No description* 
 
 
@@ -169,6 +172,7 @@ onNotApplicable(_data: NagLoggerNotApplicableData): void
   * **ruleId** (<code>string</code>)  *No description* 
   * **ruleInfo** (<code>string</code>)  *No description* 
   * **ruleLevel** (<code>[NagMessageLevel](#cdk-nag-nagmessagelevel)</code>)  *No description* 
+  * **ruleOriginalName** (<code>string</code>)  *No description* 
 
 
 
@@ -188,6 +192,7 @@ onSuppressed(data: NagLoggerSuppressedData): void
   * **ruleId** (<code>string</code>)  *No description* 
   * **ruleInfo** (<code>string</code>)  *No description* 
   * **ruleLevel** (<code>[NagMessageLevel](#cdk-nag-nagmessagelevel)</code>)  *No description* 
+  * **ruleOriginalName** (<code>string</code>)  *No description* 
   * **findingId** (<code>string</code>)  *No description* 
   * **suppressionReason** (<code>string</code>)  *No description* 
 
@@ -209,6 +214,7 @@ onSuppressedError(data: NagLoggerSuppressedErrorData): void
   * **ruleId** (<code>string</code>)  *No description* 
   * **ruleInfo** (<code>string</code>)  *No description* 
   * **ruleLevel** (<code>[NagMessageLevel](#cdk-nag-nagmessagelevel)</code>)  *No description* 
+  * **ruleOriginalName** (<code>string</code>)  *No description* 
   * **errorMessage** (<code>string</code>)  *No description* 
   * **errorSuppressionReason** (<code>string</code>)  *No description* 
 
@@ -556,6 +562,7 @@ onCompliance(data: NagLoggerComplianceData): void
   * **ruleId** (<code>string</code>)  *No description* 
   * **ruleInfo** (<code>string</code>)  *No description* 
   * **ruleLevel** (<code>[NagMessageLevel](#cdk-nag-nagmessagelevel)</code>)  *No description* 
+  * **ruleOriginalName** (<code>string</code>)  *No description* 
 
 
 
@@ -575,6 +582,7 @@ onError(data: NagLoggerErrorData): void
   * **ruleId** (<code>string</code>)  *No description* 
   * **ruleInfo** (<code>string</code>)  *No description* 
   * **ruleLevel** (<code>[NagMessageLevel](#cdk-nag-nagmessagelevel)</code>)  *No description* 
+  * **ruleOriginalName** (<code>string</code>)  *No description* 
   * **errorMessage** (<code>string</code>)  *No description* 
 
 
@@ -595,6 +603,7 @@ onNonCompliance(data: NagLoggerNonComplianceData): void
   * **ruleId** (<code>string</code>)  *No description* 
   * **ruleInfo** (<code>string</code>)  *No description* 
   * **ruleLevel** (<code>[NagMessageLevel](#cdk-nag-nagmessagelevel)</code>)  *No description* 
+  * **ruleOriginalName** (<code>string</code>)  *No description* 
   * **findingId** (<code>string</code>)  *No description* 
 
 
@@ -615,6 +624,7 @@ onNotApplicable(data: NagLoggerNotApplicableData): void
   * **ruleId** (<code>string</code>)  *No description* 
   * **ruleInfo** (<code>string</code>)  *No description* 
   * **ruleLevel** (<code>[NagMessageLevel](#cdk-nag-nagmessagelevel)</code>)  *No description* 
+  * **ruleOriginalName** (<code>string</code>)  *No description* 
 
 
 
@@ -634,6 +644,7 @@ onSuppressed(data: NagLoggerSuppressedData): void
   * **ruleId** (<code>string</code>)  *No description* 
   * **ruleInfo** (<code>string</code>)  *No description* 
   * **ruleLevel** (<code>[NagMessageLevel](#cdk-nag-nagmessagelevel)</code>)  *No description* 
+  * **ruleOriginalName** (<code>string</code>)  *No description* 
   * **findingId** (<code>string</code>)  *No description* 
   * **suppressionReason** (<code>string</code>)  *No description* 
 
@@ -655,6 +666,7 @@ onSuppressedError(data: NagLoggerSuppressedErrorData): void
   * **ruleId** (<code>string</code>)  *No description* 
   * **ruleInfo** (<code>string</code>)  *No description* 
   * **ruleLevel** (<code>[NagMessageLevel](#cdk-nag-nagmessagelevel)</code>)  *No description* 
+  * **ruleOriginalName** (<code>string</code>)  *No description* 
   * **errorMessage** (<code>string</code>)  *No description* 
   * **errorSuppressionReason** (<code>string</code>)  *No description* 
 
@@ -676,6 +688,7 @@ protected initializeStackReport(data: NagLoggerBaseData): void
   * **ruleId** (<code>string</code>)  *No description* 
   * **ruleInfo** (<code>string</code>)  *No description* 
   * **ruleLevel** (<code>[NagMessageLevel](#cdk-nag-nagmessagelevel)</code>)  *No description* 
+  * **ruleOriginalName** (<code>string</code>)  *No description* 
 
 
 
@@ -1132,6 +1145,7 @@ onCompliance(data: NagLoggerComplianceData): void
   * **ruleId** (<code>string</code>)  *No description* 
   * **ruleInfo** (<code>string</code>)  *No description* 
   * **ruleLevel** (<code>[NagMessageLevel](#cdk-nag-nagmessagelevel)</code>)  *No description* 
+  * **ruleOriginalName** (<code>string</code>)  *No description* 
 
 
 
@@ -1151,6 +1165,7 @@ onError(data: NagLoggerErrorData): void
   * **ruleId** (<code>string</code>)  *No description* 
   * **ruleInfo** (<code>string</code>)  *No description* 
   * **ruleLevel** (<code>[NagMessageLevel](#cdk-nag-nagmessagelevel)</code>)  *No description* 
+  * **ruleOriginalName** (<code>string</code>)  *No description* 
   * **errorMessage** (<code>string</code>)  *No description* 
 
 
@@ -1171,6 +1186,7 @@ onNonCompliance(data: NagLoggerNonComplianceData): void
   * **ruleId** (<code>string</code>)  *No description* 
   * **ruleInfo** (<code>string</code>)  *No description* 
   * **ruleLevel** (<code>[NagMessageLevel](#cdk-nag-nagmessagelevel)</code>)  *No description* 
+  * **ruleOriginalName** (<code>string</code>)  *No description* 
   * **findingId** (<code>string</code>)  *No description* 
 
 
@@ -1191,6 +1207,7 @@ onNotApplicable(data: NagLoggerNotApplicableData): void
   * **ruleId** (<code>string</code>)  *No description* 
   * **ruleInfo** (<code>string</code>)  *No description* 
   * **ruleLevel** (<code>[NagMessageLevel](#cdk-nag-nagmessagelevel)</code>)  *No description* 
+  * **ruleOriginalName** (<code>string</code>)  *No description* 
 
 
 
@@ -1210,6 +1227,7 @@ onSuppressed(data: NagLoggerSuppressedData): void
   * **ruleId** (<code>string</code>)  *No description* 
   * **ruleInfo** (<code>string</code>)  *No description* 
   * **ruleLevel** (<code>[NagMessageLevel](#cdk-nag-nagmessagelevel)</code>)  *No description* 
+  * **ruleOriginalName** (<code>string</code>)  *No description* 
   * **findingId** (<code>string</code>)  *No description* 
   * **suppressionReason** (<code>string</code>)  *No description* 
 
@@ -1231,6 +1249,7 @@ onSuppressedError(data: NagLoggerSuppressedErrorData): void
   * **ruleId** (<code>string</code>)  *No description* 
   * **ruleInfo** (<code>string</code>)  *No description* 
   * **ruleLevel** (<code>[NagMessageLevel](#cdk-nag-nagmessagelevel)</code>)  *No description* 
+  * **ruleOriginalName** (<code>string</code>)  *No description* 
   * **errorMessage** (<code>string</code>)  *No description* 
   * **errorSuppressionReason** (<code>string</code>)  *No description* 
 
@@ -1282,6 +1301,7 @@ Name | Type | Description
 **ruleId** | <code>string</code> | <span></span>
 **ruleInfo** | <code>string</code> | <span></span>
 **ruleLevel** | <code>[NagMessageLevel](#cdk-nag-nagmessagelevel)</code> | <span></span>
+**ruleOriginalName** | <code>string</code> | <span></span>
 
 
 
@@ -1300,6 +1320,7 @@ Name | Type | Description
 **ruleId** | <code>string</code> | <span></span>
 **ruleInfo** | <code>string</code> | <span></span>
 **ruleLevel** | <code>[NagMessageLevel](#cdk-nag-nagmessagelevel)</code> | <span></span>
+**ruleOriginalName** | <code>string</code> | <span></span>
 
 
 
@@ -1319,6 +1340,7 @@ Name | Type | Description
 **ruleId** | <code>string</code> | <span></span>
 **ruleInfo** | <code>string</code> | <span></span>
 **ruleLevel** | <code>[NagMessageLevel](#cdk-nag-nagmessagelevel)</code> | <span></span>
+**ruleOriginalName** | <code>string</code> | <span></span>
 
 
 
@@ -1338,6 +1360,7 @@ Name | Type | Description
 **ruleId** | <code>string</code> | <span></span>
 **ruleInfo** | <code>string</code> | <span></span>
 **ruleLevel** | <code>[NagMessageLevel](#cdk-nag-nagmessagelevel)</code> | <span></span>
+**ruleOriginalName** | <code>string</code> | <span></span>
 
 
 
@@ -1356,6 +1379,7 @@ Name | Type | Description
 **ruleId** | <code>string</code> | <span></span>
 **ruleInfo** | <code>string</code> | <span></span>
 **ruleLevel** | <code>[NagMessageLevel](#cdk-nag-nagmessagelevel)</code> | <span></span>
+**ruleOriginalName** | <code>string</code> | <span></span>
 
 
 
@@ -1375,6 +1399,7 @@ Name | Type | Description
 **ruleId** | <code>string</code> | <span></span>
 **ruleInfo** | <code>string</code> | <span></span>
 **ruleLevel** | <code>[NagMessageLevel](#cdk-nag-nagmessagelevel)</code> | <span></span>
+**ruleOriginalName** | <code>string</code> | <span></span>
 **suppressionReason** | <code>string</code> | <span></span>
 
 
@@ -1396,6 +1421,7 @@ Name | Type | Description
 **ruleId** | <code>string</code> | <span></span>
 **ruleInfo** | <code>string</code> | <span></span>
 **ruleLevel** | <code>[NagMessageLevel](#cdk-nag-nagmessagelevel)</code> | <span></span>
+**ruleOriginalName** | <code>string</code> | <span></span>
 
 
 

--- a/src/nag-logger.ts
+++ b/src/nag-logger.ts
@@ -17,8 +17,9 @@ import {
  * Shared data for all INagLogger methods
  * @param nagPackName The name of the NagPack that the rule belongs to.
  * @param resource The resource the suppression is applied to.
- * @param ruleId Why the rule was triggered.
- * @param ruleInfo The id of the rule to ignore.
+ * @param ruleId The id of the rule to ignore.
+ * @param ruleOriginalName Original name of the rule.
+ * @param ruleInfo Why the rule was triggered.
  * @param ruleExplanation Why the rule exists.
  * @param ruleLevel The severity level of the rule.
  */
@@ -26,6 +27,7 @@ export interface NagLoggerBaseData {
   readonly nagPackName: string;
   readonly resource: CfnResource;
   readonly ruleId: string;
+  readonly ruleOriginalName: string;
   readonly ruleInfo: string;
   readonly ruleExplanation: string;
   readonly ruleLevel: NagMessageLevel;

--- a/src/nag-pack.ts
+++ b/src/nag-pack.ts
@@ -152,6 +152,7 @@ export abstract class NagPack implements IAspect {
       nagPackName: this.packName,
       resource: params.node,
       ruleId: ruleId,
+      ruleOriginalName: params.rule.name,
       ruleInfo: params.info,
       ruleExplanation: params.explanation,
       ruleLevel: params.level,


### PR DESCRIPTION
For use cases where we want to build further automation around CDK Nag, it's useful to be able to identify the original CDK Nag rule which was applied. This change provides loggers with the original rule name.

The practical use case I'm looking at is automating the generation of base [Threat Composer](https://github.com/awslabs/threat-composer) threat models. The idea is that based on CDK Nag's introspection of your infrastructure, we can map CDK Nag rules to particular threats that they would mitigate, and so provide a good starting point from which to build a threat model for an application.

With the rule name available in a logger, I only need to worry about mapping CDK Nag rule names to threats, rather than maintaining mappings for each nag pack's rule ID, or only supporting a specific nag pack :)