### PR TITLE
fix: AwsSolutions-APIG4 triggers for CORS preflight endpoints

### DIFF
--- a/src/rules/apigw/APIGWAuthorization.ts
+++ b/src/rules/apigw/APIGWAuthorization.ts
@@ -35,7 +35,7 @@ export default Object.defineProperty(
       if (node instanceof CfnMethod) {
         const httpMethod = NagRules.resolveIfPrimitive(node, node.httpMethod);
         if (httpMethod === 'OPTIONS' && checkCORSMethodResponses(node)) {
-          return NagRuleCompliance.COMPLIANT;
+          return NagRuleCompliance.NOT_APPLICABLE;
         }
       }
       const authorizationType = NagRules.resolveIfPrimitive(

--- a/src/rules/apigw/APIGWAuthorization.ts
+++ b/src/rules/apigw/APIGWAuthorization.ts
@@ -15,6 +15,12 @@ import { NagRuleCompliance, NagRules } from '../../nag-rules';
 export default Object.defineProperty(
   (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnMethod || node instanceof CfnRoute) {
+      if (node instanceof CfnMethod) {
+        const httpMethod = NagRules.resolveIfPrimitive(node, node.httpMethod);
+        if (httpMethod === 'OPTIONS') {
+          return NagRuleCompliance.COMPLIANT;
+        }
+      }
       const authorizationType = NagRules.resolveIfPrimitive(
         node,
         node.authorizationType

--- a/src/rules/apigw/APIGWAuthorization.ts
+++ b/src/rules/apigw/APIGWAuthorization.ts
@@ -3,10 +3,27 @@ Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
 SPDX-License-Identifier: Apache-2.0
 */
 import { parse } from 'path';
-import { CfnResource } from 'aws-cdk-lib';
+import { CfnResource, Stack } from 'aws-cdk-lib';
 import { AuthorizationType, CfnMethod } from 'aws-cdk-lib/aws-apigateway';
 import { CfnRoute } from 'aws-cdk-lib/aws-apigatewayv2';
 import { NagRuleCompliance, NagRules } from '../../nag-rules';
+
+function checkMethodResponses(node: CfnMethod): boolean {
+  const methodResponses: CfnMethod.MethodResponseProperty[] = Stack.of(
+    node
+  ).resolve(node.methodResponses);
+  return methodResponses?.every((response) => {
+    const hasCORSResponseParameter = Object.entries(
+      response.responseParameters || {}
+    ).some(
+      ([key, value]) =>
+        key.startsWith('method.response.header.Access-Control-Allow-') &&
+        value === true
+    );
+
+    return response.statusCode === '204' && hasCORSResponseParameter;
+  });
+}
 
 /**
  * APIs implement authorization
@@ -17,7 +34,7 @@ export default Object.defineProperty(
     if (node instanceof CfnMethod || node instanceof CfnRoute) {
       if (node instanceof CfnMethod) {
         const httpMethod = NagRules.resolveIfPrimitive(node, node.httpMethod);
-        if (httpMethod === 'OPTIONS') {
+        if (httpMethod === 'OPTIONS' && checkMethodResponses(node)) {
           return NagRuleCompliance.COMPLIANT;
         }
       }

--- a/src/rules/apigw/APIGWAuthorization.ts
+++ b/src/rules/apigw/APIGWAuthorization.ts
@@ -8,7 +8,7 @@ import { AuthorizationType, CfnMethod } from 'aws-cdk-lib/aws-apigateway';
 import { CfnRoute } from 'aws-cdk-lib/aws-apigatewayv2';
 import { NagRuleCompliance, NagRules } from '../../nag-rules';
 
-function checkMethodResponses(node: CfnMethod): boolean {
+function checkCORSMethodResponses(node: CfnMethod): boolean {
   const methodResponses: CfnMethod.MethodResponseProperty[] = Stack.of(
     node
   ).resolve(node.methodResponses);
@@ -34,7 +34,7 @@ export default Object.defineProperty(
     if (node instanceof CfnMethod || node instanceof CfnRoute) {
       if (node instanceof CfnMethod) {
         const httpMethod = NagRules.resolveIfPrimitive(node, node.httpMethod);
-        if (httpMethod === 'OPTIONS' && checkMethodResponses(node)) {
+        if (httpMethod === 'OPTIONS' && checkCORSMethodResponses(node)) {
           return NagRuleCompliance.COMPLIANT;
         }
       }

--- a/test/rules/APIGW.test.ts
+++ b/test/rules/APIGW.test.ts
@@ -8,6 +8,7 @@ import {
   CfnRequestValidator,
   CfnRestApi,
   CfnStage,
+  Cors,
   MethodLoggingLevel,
   RestApi,
 } from 'aws-cdk-lib/aws-apigateway';
@@ -193,6 +194,10 @@ describe('Amazon API Gateway', () => {
       });
       validateStack(stack, ruleId, TestType.NON_COMPLIANCE);
     });
+    test('Noncompliance 3', () => {
+      new RestApi(stack, 'rRestApi').root.addMethod('OPTIONS');
+      validateStack(stack, ruleId, TestType.NON_COMPLIANCE);
+    });
     test('Compliance 1', () => {
       new RestApi(stack, 'rRestApi', {
         defaultMethodOptions: { authorizationType: AuthorizationType.CUSTOM },
@@ -206,7 +211,12 @@ describe('Amazon API Gateway', () => {
       validateStack(stack, ruleId, TestType.COMPLIANCE);
     });
     test('Compliance 2', () => {
-      new RestApi(stack, 'rRestApi').root.addMethod('OPTIONS');
+      new RestApi(stack, 'rRestApi').root.addCorsPreflight({
+        allowOrigins: Cors.ALL_ORIGINS,
+        allowHeaders: Cors.DEFAULT_HEADERS,
+        allowMethods: Cors.ALL_METHODS,
+        allowCredentials: true,
+      });
       validateStack(stack, ruleId, TestType.COMPLIANCE);
     });
   });

--- a/test/rules/APIGW.test.ts
+++ b/test/rules/APIGW.test.ts
@@ -193,7 +193,7 @@ describe('Amazon API Gateway', () => {
       });
       validateStack(stack, ruleId, TestType.NON_COMPLIANCE);
     });
-    test('Compliance', () => {
+    test('Compliance 1', () => {
       new RestApi(stack, 'rRestApi', {
         defaultMethodOptions: { authorizationType: AuthorizationType.CUSTOM },
       }).root.addMethod('ANY');
@@ -203,6 +203,10 @@ describe('Amazon API Gateway', () => {
         authorizationType: 'CUSTOM',
         authorizerId: 'baz',
       });
+      validateStack(stack, ruleId, TestType.COMPLIANCE);
+    });
+    test('Compliance 2', () => {
+      new RestApi(stack, 'rRestApi').root.addMethod('OPTIONS');
       validateStack(stack, ruleId, TestType.COMPLIANCE);
     });
   });

--- a/test/rules/APIGW.test.ts
+++ b/test/rules/APIGW.test.ts
@@ -183,11 +183,11 @@ describe('Amazon API Gateway', () => {
   describe('APIGWAuthorization: APIs implement authorization', () => {
     const ruleId = 'APIGWAuthorization';
     test('Noncompliance 1', () => {
-      new RestApi(stack, 'rRestApi').root.addMethod('ANY');
+      new RestApi(stack, 'RestApi').root.addMethod('ANY');
       validateStack(stack, ruleId, TestType.NON_COMPLIANCE);
     });
     test('Noncompliance 2', () => {
-      new CfnRoute(stack, 'rRoute', {
+      new CfnRoute(stack, 'Route', {
         apiId: 'foo',
         routeKey: 'ANY /bar',
         authorizationType: 'NONE',
@@ -195,14 +195,14 @@ describe('Amazon API Gateway', () => {
       validateStack(stack, ruleId, TestType.NON_COMPLIANCE);
     });
     test('Noncompliance 3', () => {
-      new RestApi(stack, 'rRestApi').root.addMethod('OPTIONS');
+      new RestApi(stack, 'RestApi').root.addMethod('OPTIONS');
       validateStack(stack, ruleId, TestType.NON_COMPLIANCE);
     });
     test('Compliance 1', () => {
-      new RestApi(stack, 'rRestApi', {
+      new RestApi(stack, 'RestApi', {
         defaultMethodOptions: { authorizationType: AuthorizationType.CUSTOM },
       }).root.addMethod('ANY');
-      new CfnRoute(stack, 'rRoute', {
+      new CfnRoute(stack, 'Route', {
         apiId: 'foo',
         routeKey: 'ANY /bar',
         authorizationType: 'CUSTOM',
@@ -211,7 +211,7 @@ describe('Amazon API Gateway', () => {
       validateStack(stack, ruleId, TestType.COMPLIANCE);
     });
     test('Compliance 2', () => {
-      new RestApi(stack, 'rRestApi').root.addCorsPreflight({
+      new RestApi(stack, 'RestApi').root.addCorsPreflight({
         allowOrigins: Cors.ALL_ORIGINS,
         allowHeaders: Cors.DEFAULT_HEADERS,
         allowMethods: Cors.ALL_METHODS,


### PR DESCRIPTION
Fixes #1815.

Currently this PR just marks all `OPTIONS` methods as compliant. I'm not sure the best way to narrow this down to specifically CORS preflight endpoints. We could try and match the template that CDK generates through its `addCorsPreflight` method, but that won't include any custom preflight endpoints which people may be using, and any changes to the CDK template may break our checks here.

I took a look at the [MDN docs for the `OPTIONS` method](https://developer.mozilla.org/en-US/docs/Web/HTTP/Methods/OPTIONS), and it seems like it has limited use cases outside of CORS. Perhaps we can mark them all as compliant?

Here is the CloudFormation CfnMethod template which CDK generates when using the following code:
```typescript
new apigateway.RestApi(this, 'TestRestApi', {
    restApiName: 'Test',
    defaultCorsPreflightOptions: {
        allowOrigins: apigateway.Cors.ALL_ORIGINS,
    },
});
```

```json
{
  "apiKeyRequired": false,
  "authorizationType": "NONE",
  "httpMethod": "OPTIONS",
  "integration": {
    "type": "MOCK",
    "requestTemplates": {
      "application/json": "{ statusCode: 200 }"
    },
    "integrationResponses": [
      {
        "statusCode": "204",
        "responseParameters": {
          "method.response.header.Access-Control-Allow-Headers": "'Content-Type,X-Amz-Date,Authorization,X-Api-Key,X-Amz-Security-Token,X-Amz-User-Agent'",
          "method.response.header.Access-Control-Allow-Origin": "'*'",
          "method.response.header.Access-Control-Allow-Methods": "'OPTIONS,GET,PUT,POST,DELETE,PATCH,HEAD'"
        }
      }
    ]
  },
  "methodResponses": [
    {
      "statusCode": "204",
      "responseParameters": {
        "method.response.header.Access-Control-Allow-Headers": true,
        "method.response.header.Access-Control-Allow-Origin": true,
        "method.response.header.Access-Control-Allow-Methods": true
      }
    }
  ],
  "resourceId": {
    "Fn::GetAtt": ["Test", "RootResourceId"]
  },
  "restApiId": {
    "Ref": "Test"
  }
}
```