### PR TITLE
fix: fixed typo resolveResourceFromInstrinsic #1898

### DIFF
--- a/API.md
+++ b/API.md
@@ -1736,6 +1736,7 @@ new NagRules()
 | **Name** | **Description** |
 | --- | --- |
 | <code><a href="#cdk-nag.NagRules.resolveIfPrimitive">resolveIfPrimitive</a></code> | Use in cases where a primitive value must be known to pass a rule. |
+| <code><a href="#cdk-nag.NagRules.resolveResourceFromInstrinsic">resolveResourceFromInstrinsic</a></code> | *No description.* |
 | <code><a href="#cdk-nag.NagRules.resolveResourceFromIntrinsic">resolveResourceFromIntrinsic</a></code> | Use in cases where a token resolves to an intrinsic function and the referenced resource must be known to pass a rule. |
 
 ---
@@ -1761,6 +1762,30 @@ The CfnResource to check.
 ---
 
 ###### `parameter`<sup>Required</sup> <a name="parameter" id="cdk-nag.NagRules.resolveIfPrimitive.parameter.parameter"></a>
+
+- *Type:* any
+
+The value to attempt to resolve.
+
+---
+
+##### ~~`resolveResourceFromInstrinsic`~~ <a name="resolveResourceFromInstrinsic" id="cdk-nag.NagRules.resolveResourceFromInstrinsic"></a>
+
+```typescript
+import { NagRules } from 'cdk-nag'
+
+NagRules.resolveResourceFromInstrinsic(node: CfnResource, parameter: any)
+```
+
+###### `node`<sup>Required</sup> <a name="node" id="cdk-nag.NagRules.resolveResourceFromInstrinsic.parameter.node"></a>
+
+- *Type:* aws-cdk-lib.CfnResource
+
+The CfnResource to check.
+
+---
+
+###### `parameter`<sup>Required</sup> <a name="parameter" id="cdk-nag.NagRules.resolveResourceFromInstrinsic.parameter.parameter"></a>
 
 - *Type:* any
 

--- a/API.md
+++ b/API.md
@@ -1736,7 +1736,7 @@ new NagRules()
 | **Name** | **Description** |
 | --- | --- |
 | <code><a href="#cdk-nag.NagRules.resolveIfPrimitive">resolveIfPrimitive</a></code> | Use in cases where a primitive value must be known to pass a rule. |
-| <code><a href="#cdk-nag.NagRules.resolveResourceFromInstrinsic">resolveResourceFromInstrinsic</a></code> | Use in cases where a token resolves to an intrinsic function and the referenced resource must be known to pass a rule. |
+| <code><a href="#cdk-nag.NagRules.resolveResourceFromIntrinsic">resolveResourceFromIntrinsic</a></code> | Use in cases where a token resolves to an intrinsic function and the referenced resource must be known to pass a rule. |
 
 ---
 
@@ -1768,17 +1768,17 @@ The value to attempt to resolve.
 
 ---
 
-##### `resolveResourceFromInstrinsic` <a name="resolveResourceFromInstrinsic" id="cdk-nag.NagRules.resolveResourceFromInstrinsic"></a>
+##### `resolveResourceFromIntrinsic` <a name="resolveResourceFromIntrinsic" id="cdk-nag.NagRules.resolveResourceFromIntrinsic"></a>
 
 ```typescript
 import { NagRules } from 'cdk-nag'
 
-NagRules.resolveResourceFromInstrinsic(node: CfnResource, parameter: any)
+NagRules.resolveResourceFromIntrinsic(node: CfnResource, parameter: any)
 ```
 
 Use in cases where a token resolves to an intrinsic function and the referenced resource must be known to pass a rule.
 
-###### `node`<sup>Required</sup> <a name="node" id="cdk-nag.NagRules.resolveResourceFromInstrinsic.parameter.node"></a>
+###### `node`<sup>Required</sup> <a name="node" id="cdk-nag.NagRules.resolveResourceFromIntrinsic.parameter.node"></a>
 
 - *Type:* aws-cdk-lib.CfnResource
 
@@ -1786,7 +1786,7 @@ The CfnResource to check.
 
 ---
 
-###### `parameter`<sup>Required</sup> <a name="parameter" id="cdk-nag.NagRules.resolveResourceFromInstrinsic.parameter.parameter"></a>
+###### `parameter`<sup>Required</sup> <a name="parameter" id="cdk-nag.NagRules.resolveResourceFromIntrinsic.parameter.parameter"></a>
 
 - *Type:* any
 

--- a/src/nag-rules.ts
+++ b/src/nag-rules.ts
@@ -69,14 +69,36 @@ export class NagRules {
       return resolvedValue;
     }
   }
-
+  
   /**
+   * @deprecated
+   * Use resolveResourceFromIntrinsic instead
+   * 
    * Use in cases where a token resolves to an intrinsic function and the referenced resource must be known to pass a rule.
    * @param node The CfnResource to check.
    * @param parameter The value to attempt to resolve.
    * @returns Return the Logical resource Id if resolves to a intrinsic function, otherwise the resolved provided value.
    */
   static resolveResourceFromInstrinsic(node: CfnResource, parameter: any): any {
+    const resolvedValue = Stack.of(node).resolve(parameter);
+    const ref = resolvedValue?.Ref;
+    const getAtt = resolvedValue?.['Fn::GetAtt'];
+    if (ref != undefined) {
+      return ref;
+    } else if (Array.isArray(getAtt) && getAtt.length > 0) {
+      return getAtt[0];
+    }
+    return resolvedValue;
+  }
+
+  /**
+   * 
+   * Use in cases where a token resolves to an intrinsic function and the referenced resource must be known to pass a rule.
+   * @param node The CfnResource to check.
+   * @param parameter The value to attempt to resolve.
+   * @returns Return the Logical resource Id if resolves to a intrinsic function, otherwise the resolved provided value.
+   */
+  static resolveResourceFromIntrinsic(node: CfnResource, parameter: any): any {
     const resolvedValue = Stack.of(node).resolve(parameter);
     const ref = resolvedValue?.Ref;
     const getAtt = resolvedValue?.['Fn::GetAtt'];

--- a/src/nag-rules.ts
+++ b/src/nag-rules.ts
@@ -80,7 +80,7 @@ export class NagRules {
    * @returns Return the Logical resource Id if resolves to a intrinsic function, otherwise the resolved provided value.
    */
   static resolveResourceFromInstrinsic(node: CfnResource, parameter: any): any {
-    return resolveResourceFromIntrinsic(node, parameter);
+    return this.resolveResourceFromIntrinsic(node, parameter);
   }
   
   /**

--- a/src/nag-rules.ts
+++ b/src/nag-rules.ts
@@ -80,17 +80,9 @@ export class NagRules {
    * @returns Return the Logical resource Id if resolves to a intrinsic function, otherwise the resolved provided value.
    */
   static resolveResourceFromInstrinsic(node: CfnResource, parameter: any): any {
-    const resolvedValue = Stack.of(node).resolve(parameter);
-    const ref = resolvedValue?.Ref;
-    const getAtt = resolvedValue?.['Fn::GetAtt'];
-    if (ref != undefined) {
-      return ref;
-    } else if (Array.isArray(getAtt) && getAtt.length > 0) {
-      return getAtt[0];
-    }
-    return resolvedValue;
+    return resolveResourceFromIntrinsic(node, parameter);
   }
-
+  
   /**
    * 
    * Use in cases where a token resolves to an intrinsic function and the referenced resource must be known to pass a rule.

--- a/src/nag-rules.ts
+++ b/src/nag-rules.ts
@@ -69,11 +69,11 @@ export class NagRules {
       return resolvedValue;
     }
   }
-  
+
   /**
    * @deprecated
    * Use resolveResourceFromIntrinsic instead
-   * 
+   *
    * Use in cases where a token resolves to an intrinsic function and the referenced resource must be known to pass a rule.
    * @param node The CfnResource to check.
    * @param parameter The value to attempt to resolve.
@@ -82,9 +82,9 @@ export class NagRules {
   static resolveResourceFromInstrinsic(node: CfnResource, parameter: any): any {
     return this.resolveResourceFromIntrinsic(node, parameter);
   }
-  
+
   /**
-   * 
+   *
    * Use in cases where a token resolves to an intrinsic function and the referenced resource must be known to pass a rule.
    * @param node The CfnResource to check.
    * @param parameter The value to attempt to resolve.

--- a/src/rules/apigw/APIGWAssociatedWithWAF.ts
+++ b/src/rules/apigw/APIGWAssociatedWithWAF.ts
@@ -15,15 +15,15 @@ import { NagRuleCompliance, NagRules } from '../../nag-rules';
 export default Object.defineProperty(
   (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnStage) {
-      const stageLogicalId = NagRules.resolveResourceFromInstrinsic(
+      const stageLogicalId = NagRules.resolveResourceFromIntrinsic(
         node,
         node.ref
       );
-      const stageName = NagRules.resolveResourceFromInstrinsic(
+      const stageName = NagRules.resolveResourceFromIntrinsic(
         node,
         node.stageName
       );
-      const restApiId = NagRules.resolveResourceFromInstrinsic(
+      const restApiId = NagRules.resolveResourceFromIntrinsic(
         node,
         node.restApiId
       );

--- a/src/rules/apigw/APIGWRequestValidation.ts
+++ b/src/rules/apigw/APIGWRequestValidation.ts
@@ -14,7 +14,7 @@ import { NagRuleCompliance, NagRules } from '../../nag-rules';
 export default Object.defineProperty(
   (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnRestApi) {
-      const apiLogicalId = NagRules.resolveResourceFromInstrinsic(
+      const apiLogicalId = NagRules.resolveResourceFromIntrinsic(
         node,
         node.ref
       );
@@ -49,7 +49,7 @@ function isMatchingRequestValidator(
   node: CfnRequestValidator,
   apiLogicalId: string
 ): boolean {
-  const resourceLogicalId = NagRules.resolveResourceFromInstrinsic(
+  const resourceLogicalId = NagRules.resolveResourceFromIntrinsic(
     node,
     node.restApiId
   );

--- a/src/rules/cloudfront/CloudFrontDistributionS3OriginAccessControl.ts
+++ b/src/rules/cloudfront/CloudFrontDistributionS3OriginAccessControl.ts
@@ -25,13 +25,13 @@ export default Object.defineProperty(
           const resolvedDomainName = Stack.of(node).resolve(
             resolvedOrigin.domainName
           );
-          const originLogicalId = NagRules.resolveResourceFromInstrinsic(
+          const originLogicalId = NagRules.resolveResourceFromIntrinsic(
             node,
             resolvedDomainName
           );
           for (const child of Stack.of(node).node.findAll()) {
             if (child instanceof CfnBucket) {
-              const childLogicalId = NagRules.resolveResourceFromInstrinsic(
+              const childLogicalId = NagRules.resolveResourceFromIntrinsic(
                 child,
                 child.ref
               );
@@ -40,7 +40,7 @@ export default Object.defineProperty(
                   resolvedOrigin.originAccessControlId
                 );
                 const originAccessControlId =
-                  NagRules.resolveResourceFromInstrinsic(
+                  NagRules.resolveResourceFromIntrinsic(
                     node,
                     resolvedAccessControlId
                   );

--- a/src/rules/dynamodb/DynamoDBAutoScalingEnabled.ts
+++ b/src/rules/dynamodb/DynamoDBAutoScalingEnabled.ts
@@ -17,12 +17,12 @@ export default Object.defineProperty(
   (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnTable) {
       if (
-        NagRules.resolveResourceFromInstrinsic(node, node.billingMode) !==
+        NagRules.resolveResourceFromIntrinsic(node, node.billingMode) !==
         BillingMode.PAY_PER_REQUEST
       ) {
         const indexWriteMatches = [''];
         const indexReadMatches = [''];
-        const tableLogicalId = NagRules.resolveResourceFromInstrinsic(
+        const tableLogicalId = NagRules.resolveResourceFromIntrinsic(
           node,
           node.ref
         );

--- a/src/rules/dynamodb/DynamoDBInBackupPlan.ts
+++ b/src/rules/dynamodb/DynamoDBInBackupPlan.ts
@@ -16,7 +16,7 @@ import { NagRuleCompliance, NagRules } from '../../nag-rules';
 export default Object.defineProperty(
   (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnTable) {
-      const tableLogicalId = NagRules.resolveResourceFromInstrinsic(
+      const tableLogicalId = NagRules.resolveResourceFromIntrinsic(
         node,
         node.ref
       );

--- a/src/rules/ec2/EC2EBSInBackupPlan.ts
+++ b/src/rules/ec2/EC2EBSInBackupPlan.ts
@@ -16,7 +16,7 @@ import { NagRuleCompliance, NagRules } from '../../nag-rules';
 export default Object.defineProperty(
   (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnVolume) {
-      const volumeLogicalId = NagRules.resolveResourceFromInstrinsic(
+      const volumeLogicalId = NagRules.resolveResourceFromIntrinsic(
         node,
         node.ref
       );

--- a/src/rules/ec2/EC2EBSVolumeEncrypted.ts
+++ b/src/rules/ec2/EC2EBSVolumeEncrypted.ts
@@ -119,7 +119,7 @@ function isMatchingLaunchTemplate(
 ): boolean {
   return (
     launchTemplateName === node.launchTemplateName ||
-    launchTemplateId === NagRules.resolveResourceFromInstrinsic(node, node.ref)
+    launchTemplateId === NagRules.resolveResourceFromIntrinsic(node, node.ref)
   );
 }
 

--- a/src/rules/ec2/EC2IMDSv2Enabled.ts
+++ b/src/rules/ec2/EC2IMDSv2Enabled.ts
@@ -87,7 +87,7 @@ function isMatchingLaunchTemplate(
 ): boolean {
   return (
     launchTemplateName === node.launchTemplateName ||
-    launchTemplateId === NagRules.resolveResourceFromInstrinsic(node, node.ref)
+    launchTemplateId === NagRules.resolveResourceFromIntrinsic(node, node.ref)
   );
 }
 
@@ -97,8 +97,8 @@ function isMatchingLaunchConfiguration(
 ): boolean {
   return (
     launchConfigurationName === node.launchConfigurationName ||
-    NagRules.resolveResourceFromInstrinsic(node, launchConfigurationName) ===
-      NagRules.resolveResourceFromInstrinsic(node, node.ref)
+    NagRules.resolveResourceFromIntrinsic(node, launchConfigurationName) ===
+      NagRules.resolveResourceFromIntrinsic(node, node.ref)
   );
 }
 

--- a/src/rules/efs/EFSInBackupPlan.ts
+++ b/src/rules/efs/EFSInBackupPlan.ts
@@ -16,7 +16,7 @@ import { NagRuleCompliance, NagRules } from '../../nag-rules';
 export default Object.defineProperty(
   (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnFileSystem) {
-      const fileSystemLogicalId = NagRules.resolveResourceFromInstrinsic(
+      const fileSystemLogicalId = NagRules.resolveResourceFromIntrinsic(
         node,
         node.ref
       );

--- a/src/rules/elb/ALBWAFEnabled.ts
+++ b/src/rules/elb/ALBWAFEnabled.ts
@@ -18,7 +18,7 @@ export default Object.defineProperty(
     if (node instanceof CfnLoadBalancer) {
       const type = NagRules.resolveIfPrimitive(node, node.type);
       if (type === undefined || type === 'application') {
-        const loadBalancerLogicalId = NagRules.resolveResourceFromInstrinsic(
+        const loadBalancerLogicalId = NagRules.resolveResourceFromIntrinsic(
           node,
           node.ref
         );

--- a/src/rules/emr/EMREncryptionInTransit.ts
+++ b/src/rules/emr/EMREncryptionInTransit.ts
@@ -14,7 +14,7 @@ import { NagRuleCompliance, NagRules } from '../../nag-rules';
 export default Object.defineProperty(
   (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnCluster) {
-      const securityConfigurationId = NagRules.resolveResourceFromInstrinsic(
+      const securityConfigurationId = NagRules.resolveResourceFromIntrinsic(
         node,
         node.securityConfiguration
       );
@@ -53,7 +53,7 @@ function isMatchingSecurityConfig(
   securityConfigurationId: string
 ): boolean {
   const resolvedSecurityConfigurationLogicalId =
-    NagRules.resolveResourceFromInstrinsic(node, node.ref);
+    NagRules.resolveResourceFromIntrinsic(node, node.ref);
   if (
     resolvedSecurityConfigurationLogicalId === securityConfigurationId ||
     node.name === securityConfigurationId

--- a/src/rules/emr/EMRLocalDiskEncryption.ts
+++ b/src/rules/emr/EMRLocalDiskEncryption.ts
@@ -14,7 +14,7 @@ import { NagRuleCompliance, NagRules } from '../../nag-rules';
 export default Object.defineProperty(
   (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnCluster) {
-      const securityConfigurationId = NagRules.resolveResourceFromInstrinsic(
+      const securityConfigurationId = NagRules.resolveResourceFromIntrinsic(
         node,
         node.securityConfiguration
       );
@@ -53,7 +53,7 @@ function isMatchingSecurityConfig(
   securityConfigurationId: string
 ): boolean {
   const resolvedSecurityConfigurationLogicalId =
-    NagRules.resolveResourceFromInstrinsic(node, node.ref);
+    NagRules.resolveResourceFromIntrinsic(node, node.ref);
   if (
     resolvedSecurityConfigurationLogicalId === securityConfigurationId ||
     node.name === securityConfigurationId

--- a/src/rules/glue/GlueEncryptedCloudWatchLogs.ts
+++ b/src/rules/glue/GlueEncryptedCloudWatchLogs.ts
@@ -20,12 +20,12 @@ export default Object.defineProperty(
     if (node instanceof CfnCrawler || node instanceof CfnJob) {
       let securityConfigurationId;
       if (node instanceof CfnCrawler) {
-        securityConfigurationId = NagRules.resolveResourceFromInstrinsic(
+        securityConfigurationId = NagRules.resolveResourceFromIntrinsic(
           node,
           node.crawlerSecurityConfiguration
         );
       } else {
-        securityConfigurationId = NagRules.resolveResourceFromInstrinsic(
+        securityConfigurationId = NagRules.resolveResourceFromIntrinsic(
           node,
           node.securityConfiguration
         );
@@ -65,7 +65,7 @@ function isMatchingSecurityConfig(
   securityConfigurationId: string
 ): boolean {
   const resolvedSecurityConfigurationLogicalId =
-    NagRules.resolveResourceFromInstrinsic(node, node.ref);
+    NagRules.resolveResourceFromIntrinsic(node, node.ref);
   if (
     resolvedSecurityConfigurationLogicalId === securityConfigurationId ||
     node.name === securityConfigurationId

--- a/src/rules/glue/GlueJobBookmarkEncrypted.ts
+++ b/src/rules/glue/GlueJobBookmarkEncrypted.ts
@@ -14,7 +14,7 @@ import { NagRuleCompliance, NagRules } from '../../nag-rules';
 export default Object.defineProperty(
   (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnJob) {
-      const securityConfigurationId = NagRules.resolveResourceFromInstrinsic(
+      const securityConfigurationId = NagRules.resolveResourceFromIntrinsic(
         node,
         node.securityConfiguration
       );
@@ -53,7 +53,7 @@ function isMatchingSecurityConfig(
   securityConfigurationId: string
 ): boolean {
   const resolvedSecurityConfigurationLogicalId =
-    NagRules.resolveResourceFromInstrinsic(node, node.ref);
+    NagRules.resolveResourceFromIntrinsic(node, node.ref);
   if (
     resolvedSecurityConfigurationLogicalId === securityConfigurationId ||
     node.name === securityConfigurationId

--- a/src/rules/iam/IAMGroupHasUsers.ts
+++ b/src/rules/iam/IAMGroupHasUsers.ts
@@ -15,7 +15,7 @@ import { NagRuleCompliance, NagRules } from '../../nag-rules';
 export default Object.defineProperty(
   (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnGroup) {
-      const groupLogicalId = NagRules.resolveResourceFromInstrinsic(
+      const groupLogicalId = NagRules.resolveResourceFromIntrinsic(
         node,
         node.ref
       );

--- a/src/rules/lex/LexBotAliasEncryptedConversationLogs.ts
+++ b/src/rules/lex/LexBotAliasEncryptedConversationLogs.ts
@@ -52,7 +52,7 @@ export default Object.defineProperty(
             const cloudwatch = Stack.of(node).resolve(
               resolvedDestination.cloudWatch
             );
-            const logGroupLogicalId = NagRules.resolveResourceFromInstrinsic(
+            const logGroupLogicalId = NagRules.resolveResourceFromIntrinsic(
               node,
               cloudwatch.cloudWatchLogGroupArn
             );
@@ -61,7 +61,7 @@ export default Object.defineProperty(
               if (child instanceof CfnLogGroup) {
                 if (
                   logGroupLogicalId ===
-                  NagRules.resolveResourceFromInstrinsic(child, child.logicalId)
+                  NagRules.resolveResourceFromIntrinsic(child, child.logicalId)
                 ) {
                   found = true;
                   if (child.kmsKeyId === undefined) {

--- a/src/rules/rds/RDSInBackupPlan.ts
+++ b/src/rules/rds/RDSInBackupPlan.ts
@@ -16,10 +16,7 @@ import { NagRuleCompliance, NagRules } from '../../nag-rules';
 export default Object.defineProperty(
   (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnDBInstance) {
-      const dbLogicalId = NagRules.resolveResourceFromIntrinsic(
-        node,
-        node.ref
-      );
+      const dbLogicalId = NagRules.resolveResourceFromIntrinsic(node, node.ref);
       let found = false;
       for (const child of Stack.of(node).node.findAll()) {
         if (child instanceof CfnBackupSelection) {

--- a/src/rules/rds/RDSInBackupPlan.ts
+++ b/src/rules/rds/RDSInBackupPlan.ts
@@ -16,7 +16,7 @@ import { NagRuleCompliance, NagRules } from '../../nag-rules';
 export default Object.defineProperty(
   (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnDBInstance) {
-      const dbLogicalId = NagRules.resolveResourceFromInstrinsic(
+      const dbLogicalId = NagRules.resolveResourceFromIntrinsic(
         node,
         node.ref
       );

--- a/src/rules/redshift/RedshiftClusterUserActivityLogging.ts
+++ b/src/rules/redshift/RedshiftClusterUserActivityLogging.ts
@@ -24,8 +24,10 @@ export default Object.defineProperty(
       let found = false;
       for (const child of Stack.of(node).node.findAll()) {
         if (child instanceof CfnClusterParameterGroup) {
-          const childParameterGroupName =
-            NagRules.resolveResourceFromIntrinsic(node, child.ref);
+          const childParameterGroupName = NagRules.resolveResourceFromIntrinsic(
+            node,
+            child.ref
+          );
           if (childParameterGroupName === clusterParameterGroupName) {
             found = isCompliantClusterParameterGroup(child);
             break;

--- a/src/rules/redshift/RedshiftClusterUserActivityLogging.ts
+++ b/src/rules/redshift/RedshiftClusterUserActivityLogging.ts
@@ -14,7 +14,7 @@ import { NagRuleCompliance, NagRules } from '../../nag-rules';
 export default Object.defineProperty(
   (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnCluster) {
-      const clusterParameterGroupName = NagRules.resolveResourceFromInstrinsic(
+      const clusterParameterGroupName = NagRules.resolveResourceFromIntrinsic(
         node,
         node.clusterParameterGroupName
       );
@@ -25,7 +25,7 @@ export default Object.defineProperty(
       for (const child of Stack.of(node).node.findAll()) {
         if (child instanceof CfnClusterParameterGroup) {
           const childParameterGroupName =
-            NagRules.resolveResourceFromInstrinsic(node, child.ref);
+            NagRules.resolveResourceFromIntrinsic(node, child.ref);
           if (childParameterGroupName === clusterParameterGroupName) {
             found = isCompliantClusterParameterGroup(child);
             break;

--- a/src/rules/redshift/RedshiftRequireTlsSSL.ts
+++ b/src/rules/redshift/RedshiftRequireTlsSSL.ts
@@ -15,7 +15,7 @@ import { NagRuleCompliance, NagRules } from '../../nag-rules';
 export default Object.defineProperty(
   (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnCluster) {
-      const clusterParameterGroupName = NagRules.resolveResourceFromInstrinsic(
+      const clusterParameterGroupName = NagRules.resolveResourceFromIntrinsic(
         node,
         node.clusterParameterGroupName
       );
@@ -53,7 +53,7 @@ function isMatchingParameterGroup(
   node: CfnClusterParameterGroup,
   parameterGroupName: string
 ): boolean {
-  const parameterGroupLogicalId = NagRules.resolveResourceFromInstrinsic(
+  const parameterGroupLogicalId = NagRules.resolveResourceFromIntrinsic(
     node,
     node.ref
   );

--- a/src/rules/s3/S3BucketLoggingEnabled.ts
+++ b/src/rules/s3/S3BucketLoggingEnabled.ts
@@ -22,7 +22,7 @@ export default Object.defineProperty(
           logging.logFilePrefix == undefined)
       ) {
         let found = false;
-        const bucketLogicalId = NagRules.resolveResourceFromInstrinsic(
+        const bucketLogicalId = NagRules.resolveResourceFromIntrinsic(
           node,
           node.ref
         );

--- a/src/rules/s3/S3BucketSSLRequestsOnly.ts
+++ b/src/rules/s3/S3BucketSSLRequestsOnly.ts
@@ -15,7 +15,7 @@ import { NagRuleCompliance, NagRules } from '../../nag-rules';
 export default Object.defineProperty(
   (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnBucket) {
-      const bucketLogicalId = NagRules.resolveResourceFromInstrinsic(
+      const bucketLogicalId = NagRules.resolveResourceFromIntrinsic(
         node,
         node.ref
       );
@@ -37,7 +37,7 @@ export default Object.defineProperty(
       }
       return NagRuleCompliance.COMPLIANT;
     } else if (node instanceof CfnBucketPolicy) {
-      const bucketLogicalId = NagRules.resolveResourceFromInstrinsic(
+      const bucketLogicalId = NagRules.resolveResourceFromIntrinsic(
         node,
         node.bucket
       );
@@ -64,7 +64,7 @@ function isMatchingPolicy(
   bucketLogicalId: string,
   bucketName: string | undefined
 ): boolean {
-  const bucket = NagRules.resolveResourceFromInstrinsic(node, node.bucket);
+  const bucket = NagRules.resolveResourceFromIntrinsic(node, node.bucket);
   return bucket === bucketLogicalId || bucket === bucketName;
 }
 

--- a/src/rules/s3/S3WebBucketOAIAccess.ts
+++ b/src/rules/s3/S3WebBucketOAIAccess.ts
@@ -15,7 +15,7 @@ export default Object.defineProperty(
   (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnBucket) {
       if (node.websiteConfiguration !== undefined) {
-        const bucketLogicalId = NagRules.resolveResourceFromInstrinsic(
+        const bucketLogicalId = NagRules.resolveResourceFromIntrinsic(
           node,
           node.ref
         );
@@ -53,7 +53,7 @@ function isMatchingCompliantPolicy(
   bucketLogicalId: string,
   bucketName: string | undefined
 ): boolean {
-  const bucket = NagRules.resolveResourceFromInstrinsic(node, node.bucket);
+  const bucket = NagRules.resolveResourceFromIntrinsic(node, node.bucket);
   if (bucket !== bucketLogicalId && bucket !== bucketName) {
     return false;
   }

--- a/src/rules/secretsmanager/SecretsManagerRotationEnabled.ts
+++ b/src/rules/secretsmanager/SecretsManagerRotationEnabled.ts
@@ -18,7 +18,7 @@ import { NagRuleCompliance, NagRules } from '../../nag-rules';
 export default Object.defineProperty(
   (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnSecret) {
-      const secretLogicalId = NagRules.resolveResourceFromInstrinsic(
+      const secretLogicalId = NagRules.resolveResourceFromIntrinsic(
         node,
         node.ref
       );
@@ -79,12 +79,12 @@ function getMatchingSecretTargetAttachment(
   node: CfnSecretTargetAttachment,
   secretLogicalId: string
 ): string {
-  const resourceSecretId = NagRules.resolveResourceFromInstrinsic(
+  const resourceSecretId = NagRules.resolveResourceFromIntrinsic(
     node,
     node.secretId
   );
   if (secretLogicalId === resourceSecretId) {
-    return NagRules.resolveResourceFromInstrinsic(node, node.ref);
+    return NagRules.resolveResourceFromIntrinsic(node, node.ref);
   }
   return '';
 }
@@ -101,7 +101,7 @@ function isMatchingRotationSchedule(
   secretLogicalId: string,
   secretTargetAttachmentLogicalIds: string[]
 ): boolean {
-  const resourceSecretId = NagRules.resolveResourceFromInstrinsic(
+  const resourceSecretId = NagRules.resolveResourceFromIntrinsic(
     node,
     node.secretId
   );

--- a/src/rules/sns/SNSTopicSSLPublishOnly.ts
+++ b/src/rules/sns/SNSTopicSSLPublishOnly.ts
@@ -16,7 +16,7 @@ export default Object.defineProperty(
     if (node instanceof CfnTopic) {
       const topicKey = Stack.of(node).resolve(node.kmsMasterKeyId);
       if (topicKey === undefined) {
-        const topicLogicalId = NagRules.resolveResourceFromInstrinsic(
+        const topicLogicalId = NagRules.resolveResourceFromIntrinsic(
           node,
           node.ref
         );
@@ -57,7 +57,7 @@ function isMatchingCompliantPolicy(
 ): boolean {
   let found = false;
   for (const topic of node.topics) {
-    const resolvedTopic = NagRules.resolveResourceFromInstrinsic(node, topic);
+    const resolvedTopic = NagRules.resolveResourceFromIntrinsic(node, topic);
     if (
       resolvedTopic === topicLogicalId ||
       (topicName !== undefined && (<string>resolvedTopic).endsWith(topicName))

--- a/src/rules/sqs/SQSQueueDLQ.ts
+++ b/src/rules/sqs/SQSQueueDLQ.ts
@@ -18,7 +18,7 @@ export default Object.defineProperty(
     if (node instanceof CfnQueue) {
       const redrivePolicy = Stack.of(node).resolve(node.redrivePolicy);
       if (redrivePolicy === undefined) {
-        const queueLogicalId = NagRules.resolveResourceFromInstrinsic(
+        const queueLogicalId = NagRules.resolveResourceFromIntrinsic(
           node,
           node.ref
         );

--- a/src/rules/sqs/SQSQueueSSLRequestsOnly.ts
+++ b/src/rules/sqs/SQSQueueSSLRequestsOnly.ts
@@ -14,7 +14,7 @@ import { NagRuleCompliance, NagRules } from '../../nag-rules';
 export default Object.defineProperty(
   (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnQueue) {
-      const queueLogicalId = NagRules.resolveResourceFromInstrinsic(
+      const queueLogicalId = NagRules.resolveResourceFromIntrinsic(
         node,
         node.ref
       );
@@ -54,7 +54,7 @@ function isMatchingCompliantPolicy(
 ): boolean {
   let found = false;
   for (const queue of node.queues) {
-    const resolvedQueue = NagRules.resolveResourceFromInstrinsic(node, queue);
+    const resolvedQueue = NagRules.resolveResourceFromIntrinsic(node, queue);
     if (
       resolvedQueue === queueLogicalId ||
       (queueName !== undefined && (<string>resolvedQueue).endsWith(queueName))

--- a/src/rules/vpc/VPCFlowLogsEnabled.ts
+++ b/src/rules/vpc/VPCFlowLogsEnabled.ts
@@ -14,7 +14,7 @@ import { NagRuleCompliance, NagRules } from '../../nag-rules';
 export default Object.defineProperty(
   (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnVPC) {
-      const vpcLogicalId = NagRules.resolveResourceFromInstrinsic(
+      const vpcLogicalId = NagRules.resolveResourceFromIntrinsic(
         node,
         node.ref
       );
@@ -48,7 +48,7 @@ function isMatchingCompliantFlowLog(
   node: CfnFlowLog,
   vpcLogicalId: string
 ): boolean {
-  const resourceLogicalId = NagRules.resolveResourceFromInstrinsic(
+  const resourceLogicalId = NagRules.resolveResourceFromIntrinsic(
     node,
     node.resourceId
   );

--- a/src/rules/waf/WAFv2LoggingEnabled.ts
+++ b/src/rules/waf/WAFv2LoggingEnabled.ts
@@ -14,7 +14,7 @@ import { NagRuleCompliance, NagRules } from '../../nag-rules';
 export default Object.defineProperty(
   (node: CfnResource): NagRuleCompliance => {
     if (node instanceof CfnWebACL) {
-      const webAclLogicalId = NagRules.resolveResourceFromInstrinsic(
+      const webAclLogicalId = NagRules.resolveResourceFromIntrinsic(
         node,
         node.ref
       );


### PR DESCRIPTION
Fixes #

Removed all references to resolveResourceFromIn**s**trinsic, changed it into resolveResourceFromIntrinsic.

Kept the old resolveResourceFromIntrinsic added @deprecated so it would not kill backward compatibility.