### PR TITLE
fix: Support support ECS Container Insights with enhanced observability in AwsSolutions-ECS4

### DIFF
--- a/src/rules/ecs/ECSClusterCloudWatchContainerInsights.ts
+++ b/src/rules/ecs/ECSClusterCloudWatchContainerInsights.ts
@@ -25,7 +25,7 @@ export default Object.defineProperty(
           resolvedSetting.name &&
           resolvedSetting.name == 'containerInsights' &&
           resolvedSetting.value &&
-          resolvedSetting.value == 'enabled'
+          (resolvedSetting.value == 'enabled' || resolvedSetting.value == 'enhanced')
         ) {
           found = true;
           break;

--- a/test/rules/ECS.test.ts
+++ b/test/rules/ECS.test.ts
@@ -9,6 +9,7 @@ import {
   ContainerImage,
   Cluster,
   LogDriver,
+  ContainerInsights,
 } from 'aws-cdk-lib/aws-ecs';
 import { Aspects, Stack } from 'aws-cdk-lib/core';
 import { validateStack, TestType, TestPack } from './utils';
@@ -39,9 +40,20 @@ describe('Amazon Elastic Container Service (Amazon ECS)', () => {
       new Cluster(stack, 'rCluster', { containerInsights: false });
       validateStack(stack, ruleId, TestType.NON_COMPLIANCE);
     });
-
-    test('Compliance', () => {
+    test('Noncompliance 2', () => {
+      new Cluster(stack, 'rCluster', { containerInsightsV2: ContainerInsights.DISABLED });
+      validateStack(stack, ruleId, TestType.NON_COMPLIANCE);
+    });
+    test('Compliance 1', () => {
       new Cluster(stack, 'rCluster', { containerInsights: true });
+      validateStack(stack, ruleId, TestType.COMPLIANCE);
+    });
+    test('Compliance 2', () => {
+      new Cluster(stack, 'rCluster', { containerInsightsV2: ContainerInsights.ENABLED });
+      validateStack(stack, ruleId, TestType.COMPLIANCE);
+    });
+    test('Compliance 3', () => {
+      new Cluster(stack, 'rCluster', { containerInsightsV2: ContainerInsights.ENHANCED });
       validateStack(stack, ruleId, TestType.COMPLIANCE);
     });
   });


### PR DESCRIPTION
Fixes #1926

Accept both `enabled` and `enhanced` to be compliant values for the `containerInsights` setting.

See also: https://github.com/aws/aws-cdk/issues/32618