### PR TITLE
fix(release): use 'release' GitHub environment for publish jobs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,6 +72,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    environment: release
     if: needs.release.outputs.tag_exists != 'true' && needs.release.outputs.latest_commit == github.sha
     steps:
       - uses: actions/setup-node@v6
@@ -97,6 +98,7 @@ jobs:
     permissions:
       id-token: write
       contents: read
+    environment: release
     if: needs.release.outputs.tag_exists != 'true' && needs.release.outputs.latest_commit == github.sha
     steps:
       - uses: actions/setup-node@v6
@@ -138,6 +140,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    environment: release
     if: needs.release.outputs.tag_exists != 'true' && needs.release.outputs.latest_commit == github.sha
     steps:
       - uses: actions/setup-java@v5
@@ -185,6 +188,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    environment: release
     if: needs.release.outputs.tag_exists != 'true' && needs.release.outputs.latest_commit == github.sha
     steps:
       - uses: actions/setup-node@v6
@@ -227,6 +231,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    environment: release
     if: needs.release.outputs.tag_exists != 'true' && needs.release.outputs.latest_commit == github.sha
     steps:
       - uses: actions/setup-node@v6
@@ -268,6 +273,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+    environment: release
     if: needs.release.outputs.tag_exists != 'true' && needs.release.outputs.latest_commit == github.sha
     steps:
       - uses: actions/setup-node@v6

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -51,6 +51,7 @@ const project = new awscdk.AwsCdkConstructLibrary({
   eslintOptions: { prettier: true },
   buildWorkflow: true,
   release: true,
+  releaseEnvironment: 'release',
   gitignore: ['.vscode', '**/.DS_Store'],
 });
 project.package.addField('prettier', {


### PR DESCRIPTION
Secrets were moved to a `release` GitHub environment a few months ago, but the release workflow was never updated to reference it. This adds `releaseEnvironment: 'release'` to `.projenrc.js`, which causes projen to add `environment: release` to all publish jobs so they can access the environment-scoped secrets.

**Changes:**
- `.projenrc.js`: Added `releaseEnvironment: 'release'`
- `.github/workflows/release.yml`: Regenerated (adds `environment: release` to all 6 publish jobs)