### PR TITLE
fix: prefix using Stage Construct ID to avoid StageName colissions

### DIFF
--- a/src/nag-logger.ts
+++ b/src/nag-logger.ts
@@ -292,8 +292,7 @@ export class NagReportLogger implements INagLogger {
   protected initializeStackReport(data: NagLoggerBaseData): void {
     for (const format of this.formats) {
       const assembly = Stage.of(data.resource.stack);
-      const prefix =
-        assembly && assembly.stageName ? `${assembly.stageName}-` : '';
+      const prefix = assembly ? `${assembly.node.id}-` : '';
       const stackName = data.resource.stack.nested
         ? Names.uniqueId(data.resource.stack)
         : data.resource.stack.stackName;
@@ -324,8 +323,7 @@ export class NagReportLogger implements INagLogger {
   ): void {
     for (const format of this.formats) {
       const assembly = Stage.of(data.resource.stack);
-      const prefix =
-        assembly && assembly.stageName ? `${assembly.stageName}-` : '';
+      const prefix = assembly ? `${assembly.node.id}-` : '';
       const stackName = data.resource.stack.nested
         ? Names.uniqueId(data.resource.stack)
         : data.resource.stack.stackName;

--- a/test/Loggers.test.ts
+++ b/test/Loggers.test.ts
@@ -201,6 +201,35 @@ describe('NagReportLogger', () => {
         ])
       );
     });
+    test('Reports are generated for stages with the same name', () => {
+      const stage = new Stage(app, 'Stage1', { stageName: 'NamedStage' });
+      Aspects.of(stage).add(pack);
+
+      const stack = new Stack(stage, 'Stack1', {
+        stackName: 'NamedStack',
+      });
+      const stage2 = new Stage(app, 'Stage2', { stageName: 'NamedStage' });
+      Aspects.of(stage2).add(pack);
+
+      const stack2 = new Stack(stage2, 'Stack2', {
+        stackName: 'NamedStack',
+      });
+      new Bucket(stack, 'rBucket');
+      new Bucket(stack2, 'rBucket');
+      app.synth();
+      expect(reportLogger.getFormatStacks(NagReportFormat.CSV)).toEqual(
+        expect.arrayContaining([
+          expect.stringMatching('Stage1-NamedStack'),
+          expect.stringMatching('Stage2-NamedStack'),
+        ])
+      );
+      expect(reportLogger.getFormatStacks(NagReportFormat.JSON)).toEqual(
+        expect.arrayContaining([
+          expect.stringMatching('Stage1-NamedStack'),
+          expect.stringMatching('Stage2-NamedStack'),
+        ])
+      );
+    });
   });
   describe('CSV', () => {
     function getReportLines(reportStack: string): string[] {


### PR DESCRIPTION
Uses Stage ID instead of StageName as you can have multiple Stages with the same StageName