### PR TITLE
fix: detect OpenAPI request validators for APIG2

### DIFF
--- a/src/rules/apigw/APIGWRequestValidation.ts
+++ b/src/rules/apigw/APIGWRequestValidation.ts
@@ -27,7 +27,7 @@ export default Object.defineProperty(
           }
         }
       }
-      if (!found) {
+      if (!found && !hasOpenApiRequestValidator(node)) {
         return NagRuleCompliance.NON_COMPLIANT;
       }
       return NagRuleCompliance.COMPLIANT;
@@ -58,4 +58,33 @@ function isMatchingRequestValidator(
     Stack.of(node).resolve(node.validateRequestBody) === true &&
     Stack.of(node).resolve(node.validateRequestParameters) === true
   );
+}
+
+
+/**
+ * Check whether an imported OpenAPI definition has basic request validation enabled.
+ * @param node the CfnRestApi to check
+ * returns whether a request validator in the OpenAPI body validates both body and parameters
+ */
+function hasOpenApiRequestValidator(node: CfnRestApi): boolean {
+  const body = Stack.of(node).resolve(node.body);
+  if (!body || typeof body !== 'object' || Array.isArray(body)) {
+    return false;
+  }
+
+  const validators = body['x-amazon-apigateway-request-validators'];
+  if (!validators || typeof validators !== 'object' || Array.isArray(validators)) {
+    return false;
+  }
+
+  return Object.values(validators).some(validator => {
+    if (!validator || typeof validator !== 'object' || Array.isArray(validator)) {
+      return false;
+    }
+
+    return (
+      Stack.of(node).resolve(validator['validateRequestBody']) === true &&
+      Stack.of(node).resolve(validator['validateRequestParameters']) === true
+    );
+  });
 }

--- a/test/rules/APIGW.test.ts
+++ b/test/rules/APIGW.test.ts
@@ -332,6 +332,18 @@ describe('Amazon API Gateway', () => {
         validateRequestBody: true,
         validateRequestParameters: true,
       });
+      new CfnRestApi(stack, 'OpenApiRestApi', {
+        body: {
+          openapi: '3.0.0',
+          paths: {},
+          'x-amazon-apigateway-request-validators': {
+            all: {
+              validateRequestBody: true,
+              validateRequestParameters: true,
+            },
+          },
+        },
+      });
       validateStack(stack, ruleId, TestType.COMPLIANCE);
     });
   });


### PR DESCRIPTION
## Summary
- recognize request validators declared in imported OpenAPI definitions
- add coverage for `x-amazon-apigateway-request-validators` with body and parameter validation

Fixes #1075