### PR TITLE
fix: isAcknowledged() misses acknowledgments on aws-cdk-lib >=2.262.1 due to prefix casing

### DIFF
--- a/src/nag-pack.ts
+++ b/src/nag-pack.ts
@@ -229,7 +229,8 @@ export abstract class NagPack implements IPolicyValidationPlugin {
       for (const entry of current.node.metadata) {
         if (entry.type === metadataKey && entry.data) {
           const ids = Object.keys(entry.data as Record<string, string>).map(
-            (k) => k.replace(/^annotation::/, '')
+            // aws-cdk-lib <2.262.1 wrote 'annotation::', >=2.262.1 writes 'Annotation::'
+            (k) => k.replace(/^annotation::/i, '')
           );
           if (ids.includes(ruleId)) return true;
         }
@@ -260,7 +261,7 @@ export class WriteNagSuppressionsToCloudFormationAspect implements IAspect {
           for (const [qualifiedId, reason] of Object.entries(
             entry.data as Record<string, string>
           )) {
-            const id = qualifiedId.replace(/^annotation::/, '');
+            const id = qualifiedId.replace(/^annotation::/i, '');
             if (!seen.has(id)) {
               seen.add(id);
               rules.push({ id, reason });


### PR DESCRIPTION
NagPack.isAcknowledged() strips a synthetic prefix that aws-cdk-lib's Validations.acknowledge() adds to bare (non-namespaced) rule IDs before writing them to construct metadata, so the stripped key can be compared against the real rule ID (e.g. AwsSolutions-S1).

Through aws-cdk-lib@2.261.0, that prefix was always lowercase annotation::, matching the regex here:

```
const ids = Object.keys(entry.data as Record<string, string>).map(
  (k) => k.replace(/^annotation::/, '')
);
```

As of aws-cdk-lib@2.262.1, Validations.qualifyId() was refactored to reuse a new shared constant, AnnotationPlugin.RULE_PREFIX = "Annotation" (capitalized), instead of its own internal lowercase constant. The prefix written to metadata is now Annotation::AwsSolutions-S1 instead of annotation::AwsSolutions-S1.

The regex above only matches the lowercase form, so on aws-cdk-lib >=2.262.1 the prefix is never stripped, the key never reduces to the bare rule ID, and Validations.of(construct).acknowledge({ id: "AwsSolutions-S1", ... }) silently stops suppressing anything — no error, the finding just reappears as if never acknowledged.

Compound rule IDs that embed their own :: (e.g. AwsSolutions-IAM5[Action::s3:GetBucket*]) are unaffected — qualifyId() passes those through unqualified because they don't hit the "add a prefix" branch, so this only breaks acknowledgment of simple, colon-free rule IDs like AwsSolutions-S1 or AwsSolutions-IAM4.

Here is a link to the commit that introduced the change in aws-cdk-lib: https://github.com/aws/aws-cdk/commit/75893d9fb827b7d1c27073ab2a3018b2e7edccbd
